### PR TITLE
feat: Console SDK update for version 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## 7.0.0
+
+* Breaking: Updated `$sequence` type from `number` to `string` for rows and documents.
+* Updated: Compatibility note now refers to Appwrite server `1.9.x`.
+* Updated: README badge shows API version `1.9.0`.
+* Updated: Set header `X-Appwrite-Response-Format` to `1.9.0`.
+
 ## 6.0.0
 
 * Breaking: Renamed `domains.confirmPurchase()` to `domains.updatePurchase()`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Appwrite Console SDK
 
 ![License](https://img.shields.io/github/license/appwrite/sdk-for-console.svg?style=flat-square)
-![Version](https://img.shields.io/badge/api%20version-1.8.2-blue.svg?style=flat-square)
+![Version](https://img.shields.io/badge/api%20version-1.9.0-blue.svg?style=flat-square)
 [![Build Status](https://img.shields.io/travis/com/appwrite/sdk-generator?style=flat-square)](https://travis-ci.com/appwrite/sdk-generator)
 [![Twitter Account](https://img.shields.io/twitter/follow/appwrite?color=00acee&label=twitter&style=flat-square)](https://twitter.com/appwrite)
 [![Discord](https://img.shields.io/discord/564160730845151244?label=discord&style=flat-square)](https://appwrite.io/discord)
@@ -33,7 +33,7 @@ import { Client, Account } from "@appwrite.io/console";
 To install with a CDN (content delivery network) add the following scripts to the bottom of your <body> tag, but before you use any Appwrite services:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@6.0.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@7.0.0"></script>
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@appwrite.io/console",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "license": "BSD-3-Clause",
   "main": "dist/cjs/sdk.js",
   "exports": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -400,8 +400,8 @@ class Client {
         'x-sdk-name': 'Console',
         'x-sdk-platform': 'console',
         'x-sdk-language': 'web',
-        'x-sdk-version': '6.0.0',
-        'X-Appwrite-Response-Format': '1.8.0',
+        'x-sdk-version': '7.0.0',
+        'X-Appwrite-Response-Format': '1.9.0',
     };
 
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * Appwrite Console SDK
  *
- * This SDK is compatible with Appwrite server version 1.8.x. 
+ * This SDK is compatible with Appwrite server version 1.9.x. 
  * For older versions, please check
  * [previous releases](https://github.com/appwrite/sdk-for-console/releases).
  */

--- a/src/models.ts
+++ b/src/models.ts
@@ -2631,7 +2631,7 @@ export namespace Models {
         /**
          * Row sequence ID.
          */
-        $sequence: number;
+        $sequence: string;
         /**
          * Table ID.
          */
@@ -2670,7 +2670,7 @@ export namespace Models {
         /**
          * Document sequence ID.
          */
-        $sequence: number;
+        $sequence: string;
         /**
          * Collection ID.
          */


### PR DESCRIPTION
This PR contains updates to the Console SDK for version 7.0.0.

## Changes

* Breaking: Updated `$sequence` type from `number` to `string` for rows and documents.
* Updated: Compatibility note now refers to Appwrite server `1.9.x`.
* Updated: README badge shows API version `1.9.0`.
* Updated: Set header `X-Appwrite-Response-Format` to `1.9.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `$sequence` property type changed from `number` to `string` in Row and Document models

* **Documentation**
  * Updated SDK compatibility to Appwrite server 1.9.x
  * Updated API version indicator to 1.9.0
  * Updated package version to 7.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->