### PR TITLE
Remove npm self-upgrade step from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,9 +22,6 @@ jobs:
         node-version: '22'
         registry-url: 'https://registry.npmjs.org'
 
-    - name: Update npm to latest version for OIDC support
-      run: npm install -g npm@latest
-
     - name: Determine release tag
       id: release_tag
       run: |


### PR DESCRIPTION
## Summary

- Removes `npm install -g npm@latest` step from the publish workflow
- Node 22 already ships with npm that supports OIDC provenance
- The self-upgrade step breaks on newer GitHub Actions runners due to corrupted `promise-retry` module in the pre-installed npm

## Test plan

- [ ] Re-run the publish workflow after merging