### PR TITLE
feat: SDK update for version 15.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## 15.1.0
+
+* Breaking: `listEvents` and `listGauges` on `Usage` now take `metrics` (string array, 1-10) instead of a single `metric`
+* Breaking: `UsageEventList` and `UsageGaugeList` now expose `interval` and a `metrics` array; `UsageGroup` is replaced by `UsageMetric` and `UsageDataPoint`
+* Breaking: `createDatabaseExecution` on `Compute` now posts to the `/executions` endpoint
+* Added: `resource` parameter on `Oauth2` `authorize`, `createDeviceAuthorization`, and `createToken` for RFC 8707 resource indicators
+* Added: `resources` field on the `Oauth2Authorize` model
+* Added: `service` and `resource` break-down dimensions on `Usage` `listGauges`
+* Updated: `Databases` transaction and text attribute methods are now marked deprecated in favor of `TablesDB`
+* Updated: OAuth2 server fields on the project model are now optional
+
 ## 15.0.0
 
 * Breaking: `listEvents` and `listGauges` on `Usage` now require `metric` and use dimension/interval aggregation instead of `queries`/`total`

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { Client, Account } from "@appwrite.io/console";
 To install with a CDN (content delivery network) add the following scripts to the bottom of your <body> tag, but before you use any Appwrite services:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@15.0.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@15.1.0"></script>
 ```
 
 

--- a/docs/examples/oauth2/authorize.md
+++ b/docs/examples/oauth2/authorize.md
@@ -18,7 +18,8 @@ const result = await oauth2.authorize({
     codeChallengeMethod: 's256', // optional
     prompt: '<PROMPT>', // optional
     maxAge: 0, // optional
-    authorizationDetails: '<AUTHORIZATION_DETAILS>' // optional
+    authorizationDetails: '<AUTHORIZATION_DETAILS>', // optional
+    resource: '' // optional
 });
 
 console.log(result);

--- a/docs/examples/oauth2/create-device-authorization.md
+++ b/docs/examples/oauth2/create-device-authorization.md
@@ -10,7 +10,8 @@ const oauth2 = new Oauth2(client);
 const result = await oauth2.createDeviceAuthorization({
     clientId: '<CLIENT_ID>', // optional
     scope: '<SCOPE>', // optional
-    authorizationDetails: '<AUTHORIZATION_DETAILS>' // optional
+    authorizationDetails: '<AUTHORIZATION_DETAILS>', // optional
+    resource: '' // optional
 });
 
 console.log(result);

--- a/docs/examples/oauth2/create-token.md
+++ b/docs/examples/oauth2/create-token.md
@@ -15,7 +15,8 @@ const result = await oauth2.createToken({
     clientId: '<CLIENT_ID>', // optional
     clientSecret: '<CLIENT_SECRET>', // optional
     codeVerifier: '<CODE_VERIFIER>', // optional
-    redirectUri: 'https://example.com' // optional
+    redirectUri: 'https://example.com', // optional
+    resource: '' // optional
 });
 
 console.log(result);

--- a/docs/examples/usage/list-events.md
+++ b/docs/examples/usage/list-events.md
@@ -8,7 +8,7 @@ const client = new Client()
 const usage = new Usage(client);
 
 const result = await usage.listEvents({
-    metric: '<METRIC>',
+    metrics: [],
     resource: '<RESOURCE>', // optional
     resourceId: '<RESOURCE_ID>', // optional
     interval: '1m', // optional

--- a/docs/examples/usage/list-gauges.md
+++ b/docs/examples/usage/list-gauges.md
@@ -8,7 +8,7 @@ const client = new Client()
 const usage = new Usage(client);
 
 const result = await usage.listGauges({
-    metric: '<METRIC>',
+    metrics: [],
     resourceId: '<RESOURCE_ID>', // optional
     teamId: '<TEAM_ID>', // optional
     interval: '1m', // optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appwrite.io/console",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appwrite.io/console",
-      "version": "15.0.0",
+      "version": "15.1.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@appwrite.io/console",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "15.0.0",
+  "version": "15.1.0",
   "license": "BSD-3-Clause",
   "main": "dist/cjs/sdk.js",
   "exports": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -392,7 +392,7 @@ class Client {
         'x-sdk-name': 'Console',
         'x-sdk-platform': 'console',
         'x-sdk-language': 'web',
-        'x-sdk-version': '15.0.0',
+        'x-sdk-version': '15.1.0',
         'X-Appwrite-Response-Format': '1.9.5',
     };
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -5282,59 +5282,59 @@ export namespace Models {
         /**
          * OAuth2 server status
          */
-        oAuth2ServerEnabled: boolean;
+        oAuth2ServerEnabled?: boolean;
         /**
          * OAuth2 server authorization URL
          */
-        oAuth2ServerAuthorizationUrl: string;
+        oAuth2ServerAuthorizationUrl?: string;
         /**
          * OAuth2 server allowed scopes
          */
-        oAuth2ServerScopes: string[];
+        oAuth2ServerScopes?: string[];
         /**
          * OAuth2 server accepted RFC 9396 authorization_details types
          */
-        oAuth2ServerAuthorizationDetailsTypes: string[];
+        oAuth2ServerAuthorizationDetailsTypes?: string[];
         /**
          * OAuth2 server access token duration in seconds for confidential clients
          */
-        oAuth2ServerAccessTokenDuration: number;
+        oAuth2ServerAccessTokenDuration?: number;
         /**
          * OAuth2 server refresh token duration in seconds for confidential clients
          */
-        oAuth2ServerRefreshTokenDuration: number;
+        oAuth2ServerRefreshTokenDuration?: number;
         /**
          * OAuth2 server access token duration in seconds for public clients (SPAs, mobile, native)
          */
-        oAuth2ServerPublicAccessTokenDuration: number;
+        oAuth2ServerPublicAccessTokenDuration?: number;
         /**
          * OAuth2 server refresh token duration in seconds for public clients (SPAs, mobile, native)
          */
-        oAuth2ServerPublicRefreshTokenDuration: number;
+        oAuth2ServerPublicRefreshTokenDuration?: number;
         /**
          * When enabled, PKCE is required for confidential clients (server-side flows using client_secret). PKCE is always required for public clients regardless of this setting.
          */
-        oAuth2ServerConfidentialPkce: boolean;
+        oAuth2ServerConfidentialPkce?: boolean;
         /**
          * URL to your application page where users enter the device flow user code. Empty when the Device Authorization Grant is not configured.
          */
-        oAuth2ServerVerificationUrl: string;
+        oAuth2ServerVerificationUrl?: string;
         /**
          * Number of characters in the device flow user code, excluding the formatting separator.
          */
-        oAuth2ServerUserCodeLength: number;
+        oAuth2ServerUserCodeLength?: number;
         /**
          * Character set for device flow user codes: `numeric`, `alphabetic`, or `alphanumeric`.
          */
-        oAuth2ServerUserCodeFormat: string;
+        oAuth2ServerUserCodeFormat?: string;
         /**
          * Lifetime in seconds of device flow device codes and user codes.
          */
-        oAuth2ServerDeviceCodeDuration: number;
+        oAuth2ServerDeviceCodeDuration?: number;
         /**
          * OAuth2 server discovery URL
          */
-        oAuth2ServerDiscoveryUrl: string;
+        oAuth2ServerDiscoveryUrl?: string;
     }
 
     /**
@@ -12398,15 +12398,15 @@ export namespace Models {
     }
 
     /**
-     * usageGroup
+     * usageDataPoint
      */
-    export type UsageGroup = {
+    export type UsageDataPoint = {
         /**
-         * Group start timestamp (ISO 8601).
+         * Bucket start timestamp (ISO 8601). When `interval` is omitted this is the request end time, marking the aggregate as-of moment.
          */
         time: string;
         /**
-         * Aggregated value for the group.
+         * Aggregated value for the bucket.
          */
         value: number;
         /**
@@ -12461,6 +12461,10 @@ export namespace Models {
          * External resource ID when broken down by `resourceId`.
          */
         resourceId?: string;
+        /**
+         * Resource type when broken down by `resource` (gauges only).
+         */
+        resource?: string;
     }
 
     /**
@@ -12468,17 +12472,13 @@ export namespace Models {
      */
     export type UsageEventList = {
         /**
-         * Metric key the groups describe.
-         */
-        metric: string;
-        /**
-         * Time interval size (1h or 1d).
+         * Time interval size (1h or 1d). Empty when the request omits `interval` — points then carry the request end time as their as-of marker.
          */
         interval: string;
         /**
-         * Aggregated groups ordered by time ascending.
+         * One entry per requested metric, each carrying its own points[] time series (sums per bucket / dimension over time).
          */
-        groups: UsageGroup[];
+        metrics: UsageMetric[];
     }
 
     /**
@@ -12486,17 +12486,27 @@ export namespace Models {
      */
     export type UsageGaugeList = {
         /**
-         * Metric key the groups describe.
-         */
-        metric: string;
-        /**
-         * Time interval size (1h or 1d).
+         * Time interval size (1h or 1d). Empty when the request omits `interval` — points then carry the request end time as their as-of marker.
          */
         interval: string;
         /**
-         * Aggregated groups ordered by time ascending. Each group carries the latest snapshot in its interval (argMax over time).
+         * One entry per requested metric, each carrying its own points[] time series (latest-snapshot per bucket / dimension via argMax over time).
          */
-        groups: UsageGroup[];
+        metrics: UsageMetric[];
+    }
+
+    /**
+     * usageMetric
+     */
+    export type UsageMetric = {
+        /**
+         * Metric key this series describes.
+         */
+        metric: string;
+        /**
+         * Data points for this metric, ordered by time ascending. With `interval`, each entry is one bucket; without, each entry is one row of the dimensional or aggregate breakdown.
+         */
+        points: UsageDataPoint[];
     }
 
     /**
@@ -12997,6 +13007,10 @@ export namespace Models {
          * Requested OAuth2 scopes the user is being asked to consent to.
          */
         scopes: string[];
+        /**
+         * Requested RFC 8707 resource indicators the user is being asked to consent to.
+         */
+        resources: string[];
         /**
          * Requested authorization_details the user is being asked to consent to, as a JSON string. Each entry has a `type` plus project-defined fields.
          */

--- a/src/services/compute.ts
+++ b/src/services/compute.ts
@@ -1728,7 +1728,7 @@ export class Compute {
     }
 
     /**
-     * Execute SQL through the console-facing Cloud endpoint. Cloud proxies through the edge platform to the per-database SQL API sidecar. Application traffic should bypass cloud entirely and POST directly to the per-database hostname: `https://db-{project}-{db}.{region}.appwrite.center/v1/sql/execute` with an `X-Appwrite-Key` header — that path scales to the whole DB fleet without a per-query cloud round-trip. The statement type must be on the database's configured allow-list. Use bound parameters for any user-supplied values — the API does not interpolate raw strings.
+     * Execute SQL through the console-facing Cloud endpoint. Cloud proxies through the edge platform to the per-database SQL API sidecar. Application traffic should bypass cloud entirely and POST directly to the per-database hostname: `https://db-{project}-{db}.{region}.appwrite.center/v1/sql/executions` with an `X-Appwrite-Key` header — that path scales to the whole DB fleet without a per-query cloud round-trip. The statement type must be on the database's configured allow-list. Use bound parameters for any user-supplied values — the API does not interpolate raw strings.
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.sql - SQL statement to execute. Exactly one statement per request.
@@ -1739,7 +1739,7 @@ export class Compute {
      */
     createDatabaseExecution(params: { databaseId: string, sql: string, bindings?: object, timeoutSeconds?: number }): Promise<Models.DedicatedDatabaseExecution>;
     /**
-     * Execute SQL through the console-facing Cloud endpoint. Cloud proxies through the edge platform to the per-database SQL API sidecar. Application traffic should bypass cloud entirely and POST directly to the per-database hostname: `https://db-{project}-{db}.{region}.appwrite.center/v1/sql/execute` with an `X-Appwrite-Key` header — that path scales to the whole DB fleet without a per-query cloud round-trip. The statement type must be on the database's configured allow-list. Use bound parameters for any user-supplied values — the API does not interpolate raw strings.
+     * Execute SQL through the console-facing Cloud endpoint. Cloud proxies through the edge platform to the per-database SQL API sidecar. Application traffic should bypass cloud entirely and POST directly to the per-database hostname: `https://db-{project}-{db}.{region}.appwrite.center/v1/sql/executions` with an `X-Appwrite-Key` header — that path scales to the whole DB fleet without a per-query cloud round-trip. The statement type must be on the database's configured allow-list. Use bound parameters for any user-supplied values — the API does not interpolate raw strings.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} sql - SQL statement to execute. Exactly one statement per request.
@@ -1779,7 +1779,7 @@ export class Compute {
             throw new AppwriteException('Missing required parameter: "sql"');
         }
 
-        const apiPath = '/compute/databases/{databaseId}/execution'.replace('{databaseId}', encodeURIComponent(String(databaseId)));
+        const apiPath = '/compute/databases/{databaseId}/executions'.replace('{databaseId}', encodeURIComponent(String(databaseId)));
         const payload: Payload = {};
         if (typeof sql !== 'undefined') {
             payload['sql'] = sql;

--- a/src/services/databases.ts
+++ b/src/services/databases.ts
@@ -168,6 +168,7 @@ export class Databases {
      * @param {string[]} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries).
      * @throws {AppwriteException}
      * @returns {Promise<Models.TransactionList>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.listTransactions` instead.
      */
     listTransactions(params?: { queries?: string[] }): Promise<Models.TransactionList>;
     /**
@@ -221,6 +222,7 @@ export class Databases {
      * @param {number} params.ttl - Seconds before the transaction expires.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Transaction>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.createTransaction` instead.
      */
     createTransaction(params?: { ttl?: number }): Promise<Models.Transaction>;
     /**
@@ -275,6 +277,7 @@ export class Databases {
      * @param {string} params.transactionId - Transaction ID.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Transaction>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.getTransaction` instead.
      */
     getTransaction(params: { transactionId: string }): Promise<Models.Transaction>;
     /**
@@ -330,6 +333,7 @@ export class Databases {
      * @param {boolean} params.rollback - Rollback transaction?
      * @throws {AppwriteException}
      * @returns {Promise<Models.Transaction>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.updateTransaction` instead.
      */
     updateTransaction(params: { transactionId: string, commit?: boolean, rollback?: boolean }): Promise<Models.Transaction>;
     /**
@@ -397,6 +401,7 @@ export class Databases {
      * @param {string} params.transactionId - Transaction ID.
      * @throws {AppwriteException}
      * @returns {Promise<{}>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.deleteTransaction` instead.
      */
     deleteTransaction(params: { transactionId: string }): Promise<{}>;
     /**
@@ -451,6 +456,7 @@ export class Databases {
      * @param {object[]} params.operations - Array of staged operations.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Transaction>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.createOperations` instead.
      */
     createOperations(params: { transactionId: string, operations?: object[] }): Promise<Models.Transaction>;
     /**
@@ -3102,6 +3108,7 @@ export class Databases {
      * @param {boolean} params.encrypt - Toggle encryption for the attribute. Encryption enhances security by not storing any plain text values in the database. However, encrypted attributes cannot be queried.
      * @throws {AppwriteException}
      * @returns {Promise<Models.AttributeLongtext>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.createLongtextColumn` instead.
      */
     createLongtextAttribute(params: { databaseId: string, collectionId: string, key: string, required: boolean, xdefault?: string, array?: boolean, encrypt?: boolean }): Promise<Models.AttributeLongtext>;
     /**
@@ -3206,6 +3213,7 @@ export class Databases {
      * @param {string} params.newKey - New Attribute Key.
      * @throws {AppwriteException}
      * @returns {Promise<Models.AttributeLongtext>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.updateLongtextColumn` instead.
      */
     updateLongtextAttribute(params: { databaseId: string, collectionId: string, key: string, required: boolean, xdefault?: string, newKey?: string }): Promise<Models.AttributeLongtext>;
     /**
@@ -3305,6 +3313,7 @@ export class Databases {
      * @param {boolean} params.encrypt - Toggle encryption for the attribute. Encryption enhances security by not storing any plain text values in the database. However, encrypted attributes cannot be queried.
      * @throws {AppwriteException}
      * @returns {Promise<Models.AttributeMediumtext>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.createMediumtextColumn` instead.
      */
     createMediumtextAttribute(params: { databaseId: string, collectionId: string, key: string, required: boolean, xdefault?: string, array?: boolean, encrypt?: boolean }): Promise<Models.AttributeMediumtext>;
     /**
@@ -3409,6 +3418,7 @@ export class Databases {
      * @param {string} params.newKey - New Attribute Key.
      * @throws {AppwriteException}
      * @returns {Promise<Models.AttributeMediumtext>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.updateMediumtextColumn` instead.
      */
     updateMediumtextAttribute(params: { databaseId: string, collectionId: string, key: string, required: boolean, xdefault?: string, newKey?: string }): Promise<Models.AttributeMediumtext>;
     /**
@@ -4297,6 +4307,7 @@ export class Databases {
      * @param {boolean} params.encrypt - Toggle encryption for the attribute. Encryption enhances security by not storing any plain text values in the database. However, encrypted attributes cannot be queried.
      * @throws {AppwriteException}
      * @returns {Promise<Models.AttributeText>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.createTextColumn` instead.
      */
     createTextAttribute(params: { databaseId: string, collectionId: string, key: string, required: boolean, xdefault?: string, array?: boolean, encrypt?: boolean }): Promise<Models.AttributeText>;
     /**
@@ -4401,6 +4412,7 @@ export class Databases {
      * @param {string} params.newKey - New Attribute Key.
      * @throws {AppwriteException}
      * @returns {Promise<Models.AttributeText>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.updateTextColumn` instead.
      */
     updateTextAttribute(params: { databaseId: string, collectionId: string, key: string, required: boolean, xdefault?: string, newKey?: string }): Promise<Models.AttributeText>;
     /**
@@ -4699,6 +4711,7 @@ export class Databases {
      * @param {boolean} params.encrypt - Toggle encryption for the attribute. Encryption enhances security by not storing any plain text values in the database. However, encrypted attributes cannot be queried.
      * @throws {AppwriteException}
      * @returns {Promise<Models.AttributeVarchar>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.createVarcharColumn` instead.
      */
     createVarcharAttribute(params: { databaseId: string, collectionId: string, key: string, size: number, required: boolean, xdefault?: string, array?: boolean, encrypt?: boolean }): Promise<Models.AttributeVarchar>;
     /**
@@ -4813,6 +4826,7 @@ export class Databases {
      * @param {string} params.newKey - New Attribute Key.
      * @throws {AppwriteException}
      * @returns {Promise<Models.AttributeVarchar>}
+     * @deprecated This API has been deprecated since 1.8.0. Please use `TablesDB.updateVarcharColumn` instead.
      */
     updateVarcharAttribute(params: { databaseId: string, collectionId: string, key: string, required: boolean, xdefault?: string, size?: number, newKey?: string }): Promise<Models.AttributeVarchar>;
     /**

--- a/src/services/oauth-2.ts
+++ b/src/services/oauth-2.ts
@@ -88,10 +88,11 @@ export class Oauth2 {
      * @param {string} params.prompt - OIDC prompt parameter for customization of consent screen. Space-separated list of: none, login, consent, select_account.
      * @param {number} params.maxAge - OIDC max_age paraleter for customization of consent screen. Maximum allowable elapsed time in seconds since the user last authenticated. If exceeded, re-authentication is required.
      * @param {string} params.authorizationDetails - Rich authorization request. JSON array of objects, each with a `type` and project-defined fields
+     * @param {string} params.resource - RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Oauth2Authorize>}
      */
-    authorize(params: { clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string }): Promise<Models.Oauth2Authorize>;
+    authorize(params: { clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string, resource?: string }): Promise<Models.Oauth2Authorize>;
     /**
      * Begin the OAuth2 authorization flow. When called without a session, the user is redirected to the consent screen without grant ID. When called with a session, the redirect URL includes param for grant ID. You can pass Accept header of `application/json` to receive a JSON response instead of a redirect.
      *
@@ -106,19 +107,20 @@ export class Oauth2 {
      * @param {string} prompt - OIDC prompt parameter for customization of consent screen. Space-separated list of: none, login, consent, select_account.
      * @param {number} maxAge - OIDC max_age paraleter for customization of consent screen. Maximum allowable elapsed time in seconds since the user last authenticated. If exceeded, re-authentication is required.
      * @param {string} authorizationDetails - Rich authorization request. JSON array of objects, each with a `type` and project-defined fields
+     * @param {string} resource - RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Oauth2Authorize>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    authorize(clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string): Promise<Models.Oauth2Authorize>;
+    authorize(clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string, resource?: string): Promise<Models.Oauth2Authorize>;
     authorize(
-        paramsOrFirst: { clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string } | string,
-        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (number)?, (string)?]    
+        paramsOrFirst: { clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string, resource?: string } | string,
+        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (number)?, (string)?, (string)?]    
     ): Promise<Models.Oauth2Authorize> {
-        let params: { clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string };
+        let params: { clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string, resource?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string };
+            params = (paramsOrFirst || {}) as { clientId: string, redirectUri: string, responseType: string, scope: string, state?: string, nonce?: string, codeChallenge?: string, codeChallengeMethod?: string, prompt?: string, maxAge?: number, authorizationDetails?: string, resource?: string };
         } else {
             params = {
                 clientId: paramsOrFirst as string,
@@ -131,7 +133,8 @@ export class Oauth2 {
                 codeChallengeMethod: rest[6] as string,
                 prompt: rest[7] as string,
                 maxAge: rest[8] as number,
-                authorizationDetails: rest[9] as string            
+                authorizationDetails: rest[9] as string,
+                resource: rest[10] as string            
             };
         }
         
@@ -146,6 +149,7 @@ export class Oauth2 {
         const prompt = params.prompt;
         const maxAge = params.maxAge;
         const authorizationDetails = params.authorizationDetails;
+        const resource = params.resource;
 
         if (typeof clientId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "clientId"');
@@ -195,6 +199,9 @@ export class Oauth2 {
         if (typeof authorizationDetails !== 'undefined') {
             payload['authorization_details'] = authorizationDetails;
         }
+        if (typeof resource !== 'undefined') {
+            payload['resource'] = resource;
+        }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
         const apiHeaders: { [header: string]: string } = {
@@ -215,40 +222,44 @@ export class Oauth2 {
      * @param {string} params.clientId - OAuth2 client ID.
      * @param {string} params.scope - Space-separated OAuth2 scopes. Can include project scopes, and built-in scopes: `openid`, `email`, `profile`.
      * @param {string} params.authorizationDetails - Rich authorization request. JSON array of objects, each with a `type` and project-defined fields
+     * @param {string} params.resource - RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Oauth2DeviceAuthorization>}
      */
-    createDeviceAuthorization(params?: { clientId?: string, scope?: string, authorizationDetails?: string }): Promise<Models.Oauth2DeviceAuthorization>;
+    createDeviceAuthorization(params?: { clientId?: string, scope?: string, authorizationDetails?: string, resource?: string }): Promise<Models.Oauth2DeviceAuthorization>;
     /**
      * Start the OAuth2 Device Authorization Grant. Returns the device code, user code, verification URL, expiration, and polling interval.
      *
      * @param {string} clientId - OAuth2 client ID.
      * @param {string} scope - Space-separated OAuth2 scopes. Can include project scopes, and built-in scopes: `openid`, `email`, `profile`.
      * @param {string} authorizationDetails - Rich authorization request. JSON array of objects, each with a `type` and project-defined fields
+     * @param {string} resource - RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Oauth2DeviceAuthorization>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    createDeviceAuthorization(clientId?: string, scope?: string, authorizationDetails?: string): Promise<Models.Oauth2DeviceAuthorization>;
+    createDeviceAuthorization(clientId?: string, scope?: string, authorizationDetails?: string, resource?: string): Promise<Models.Oauth2DeviceAuthorization>;
     createDeviceAuthorization(
-        paramsOrFirst?: { clientId?: string, scope?: string, authorizationDetails?: string } | string,
-        ...rest: [(string)?, (string)?]    
+        paramsOrFirst?: { clientId?: string, scope?: string, authorizationDetails?: string, resource?: string } | string,
+        ...rest: [(string)?, (string)?, (string)?]    
     ): Promise<Models.Oauth2DeviceAuthorization> {
-        let params: { clientId?: string, scope?: string, authorizationDetails?: string };
+        let params: { clientId?: string, scope?: string, authorizationDetails?: string, resource?: string };
         
         if (!paramsOrFirst || (paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { clientId?: string, scope?: string, authorizationDetails?: string };
+            params = (paramsOrFirst || {}) as { clientId?: string, scope?: string, authorizationDetails?: string, resource?: string };
         } else {
             params = {
                 clientId: paramsOrFirst as string,
                 scope: rest[0] as string,
-                authorizationDetails: rest[1] as string            
+                authorizationDetails: rest[1] as string,
+                resource: rest[2] as string            
             };
         }
         
         const clientId = params.clientId;
         const scope = params.scope;
         const authorizationDetails = params.authorizationDetails;
+        const resource = params.resource;
 
 
         const apiPath = '/oauth2/{project_id}/device_authorization'.replace('{project_id}', encodeURIComponent(String(this.client.config.project)));
@@ -261,6 +272,9 @@ export class Oauth2 {
         }
         if (typeof authorizationDetails !== 'undefined') {
             payload['authorization_details'] = authorizationDetails;
+        }
+        if (typeof resource !== 'undefined') {
+            payload['resource'] = resource;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
@@ -618,10 +632,11 @@ export class Oauth2 {
      * @param {string} params.clientSecret - OAuth2 client secret. Required for confidential apps.
      * @param {string} params.codeVerifier - PKCE code verifier. Required for public apps.
      * @param {string} params.redirectUri - Redirect URI. Required for `authorization_code` grant type.
+     * @param {string} params.resource - RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Oauth2Token>}
      */
-    createToken(params: { grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string }): Promise<Models.Oauth2Token>;
+    createToken(params: { grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string, resource?: string }): Promise<Models.Oauth2Token>;
     /**
      * Exchange an OAuth2 authorization code, refresh token, or device code for access and refresh tokens.
      *
@@ -633,19 +648,20 @@ export class Oauth2 {
      * @param {string} clientSecret - OAuth2 client secret. Required for confidential apps.
      * @param {string} codeVerifier - PKCE code verifier. Required for public apps.
      * @param {string} redirectUri - Redirect URI. Required for `authorization_code` grant type.
+     * @param {string} resource - RFC 8707 resource indicator URI or URI list. Each value must be an absolute URI without a fragment.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Oauth2Token>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    createToken(grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string): Promise<Models.Oauth2Token>;
+    createToken(grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string, resource?: string): Promise<Models.Oauth2Token>;
     createToken(
-        paramsOrFirst: { grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string } | string,
-        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (string)?]    
+        paramsOrFirst: { grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string, resource?: string } | string,
+        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (string)?, (string)?]    
     ): Promise<Models.Oauth2Token> {
-        let params: { grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string };
+        let params: { grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string, resource?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string };
+            params = (paramsOrFirst || {}) as { grantType: string, code?: string, refreshToken?: string, deviceCode?: string, clientId?: string, clientSecret?: string, codeVerifier?: string, redirectUri?: string, resource?: string };
         } else {
             params = {
                 grantType: paramsOrFirst as string,
@@ -655,7 +671,8 @@ export class Oauth2 {
                 clientId: rest[3] as string,
                 clientSecret: rest[4] as string,
                 codeVerifier: rest[5] as string,
-                redirectUri: rest[6] as string            
+                redirectUri: rest[6] as string,
+                resource: rest[7] as string            
             };
         }
         
@@ -667,6 +684,7 @@ export class Oauth2 {
         const clientSecret = params.clientSecret;
         const codeVerifier = params.codeVerifier;
         const redirectUri = params.redirectUri;
+        const resource = params.resource;
 
         if (typeof grantType === 'undefined') {
             throw new AppwriteException('Missing required parameter: "grantType"');
@@ -697,6 +715,9 @@ export class Oauth2 {
         }
         if (typeof redirectUri !== 'undefined') {
             payload['redirect_uri'] = redirectUri;
+        }
+        if (typeof resource !== 'undefined') {
+            payload['resource'] = resource;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 

--- a/src/services/usage.ts
+++ b/src/services/usage.ts
@@ -11,15 +11,15 @@ export class Usage {
     }
 
     /**
-     * Aggregate usage event metrics. `metric` is required.
+     * Aggregate usage event metrics. `metrics[]` (1-10) is required; the response always contains one entry per requested metric, each with its own `points[]` time series.
      * 
      * **Two response shapes**:
-     * - Omit `interval` for a flat top-N table — one row per dimension combination, no time axis. Useful for "top 10 paths by bandwidth in the last 7 days".
-     * - Pass `interval` (`1m`, `15m`, `30m`, `1h`, `1d`) for a time series — one row per (time bucket × dimension combination).
+     * - Omit `interval` for a flat top-N table — one point per dimension combination, no time axis. Useful for "top 10 paths by bandwidth in the last 7 days".
+     * - Pass `interval` (`1m`, `15m`, `30m`, `1h`, `1d`) for a time series — one point per (time bucket × dimension combination).
      * 
-     * `dimensions[]` breaks each row down by one or more attributes (service, path, status, country, …). `resource` and `resourceId` filter the underlying events. `orderBy=value`+`orderDir=desc`+`limit=N` returns the top-N by aggregated value. When `startAt` is omitted, the default window adapts to `interval` (or 7d when interval is omitted).
+     * `dimensions[]` breaks each point down by one or more attributes (service, path, status, country, …). Pass multiple metrics to render stacked charts in one round-trip. `resource` and `resourceId` filter the underlying events. `orderBy=value`+`orderDir=desc`+`limit=N` returns the top-N by aggregated value. When `startAt` is omitted, the default window adapts to `interval` (or 7d when interval is omitted).
      *
-     * @param {string} params.metric - Metric name (required). Example: executions, network.requests.
+     * @param {string[]} params.metrics - One to ten metric names. Single-metric callers pass a one-element array. Example: `metrics[]=executions` or `metrics[]=executions&metrics[]=executions.compute` for stacked charts.
      * @param {string} params.resource - Resource type filter (singular form). Common values: function, site, database, bucket, file, webhook, team, user, project.
      * @param {string} params.resourceId - Resource id filter.
      * @param {string} params.interval - Time interval size. Omit (null) for a flat aggregate over the whole window. Allowed: 1m, 15m, 30m, 1h, 1d.
@@ -33,17 +33,17 @@ export class Usage {
      * @throws {AppwriteException}
      * @returns {Promise<Models.UsageEventList>}
      */
-    listEvents(params: { metric: string, resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number }): Promise<Models.UsageEventList>;
+    listEvents(params: { metrics: string[], resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number }): Promise<Models.UsageEventList>;
     /**
-     * Aggregate usage event metrics. `metric` is required.
+     * Aggregate usage event metrics. `metrics[]` (1-10) is required; the response always contains one entry per requested metric, each with its own `points[]` time series.
      * 
      * **Two response shapes**:
-     * - Omit `interval` for a flat top-N table — one row per dimension combination, no time axis. Useful for "top 10 paths by bandwidth in the last 7 days".
-     * - Pass `interval` (`1m`, `15m`, `30m`, `1h`, `1d`) for a time series — one row per (time bucket × dimension combination).
+     * - Omit `interval` for a flat top-N table — one point per dimension combination, no time axis. Useful for "top 10 paths by bandwidth in the last 7 days".
+     * - Pass `interval` (`1m`, `15m`, `30m`, `1h`, `1d`) for a time series — one point per (time bucket × dimension combination).
      * 
-     * `dimensions[]` breaks each row down by one or more attributes (service, path, status, country, …). `resource` and `resourceId` filter the underlying events. `orderBy=value`+`orderDir=desc`+`limit=N` returns the top-N by aggregated value. When `startAt` is omitted, the default window adapts to `interval` (or 7d when interval is omitted).
+     * `dimensions[]` breaks each point down by one or more attributes (service, path, status, country, …). Pass multiple metrics to render stacked charts in one round-trip. `resource` and `resourceId` filter the underlying events. `orderBy=value`+`orderDir=desc`+`limit=N` returns the top-N by aggregated value. When `startAt` is omitted, the default window adapts to `interval` (or 7d when interval is omitted).
      *
-     * @param {string} metric - Metric name (required). Example: executions, network.requests.
+     * @param {string[]} metrics - One to ten metric names. Single-metric callers pass a one-element array. Example: `metrics[]=executions` or `metrics[]=executions&metrics[]=executions.compute` for stacked charts.
      * @param {string} resource - Resource type filter (singular form). Common values: function, site, database, bucket, file, webhook, team, user, project.
      * @param {string} resourceId - Resource id filter.
      * @param {string} interval - Time interval size. Omit (null) for a flat aggregate over the whole window. Allowed: 1m, 15m, 30m, 1h, 1d.
@@ -58,18 +58,18 @@ export class Usage {
      * @returns {Promise<Models.UsageEventList>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    listEvents(metric: string, resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number): Promise<Models.UsageEventList>;
+    listEvents(metrics: string[], resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number): Promise<Models.UsageEventList>;
     listEvents(
-        paramsOrFirst: { metric: string, resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number } | string,
+        paramsOrFirst: { metrics: string[], resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number } | string[],
         ...rest: [(string)?, (string)?, (string)?, (string[])?, (string)?, (string)?, (string)?, (string)?, (number)?, (number)?]    
     ): Promise<Models.UsageEventList> {
-        let params: { metric: string, resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number };
+        let params: { metrics: string[], resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { metric: string, resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number };
+            params = (paramsOrFirst || {}) as { metrics: string[], resource?: string, resourceId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number };
         } else {
             params = {
-                metric: paramsOrFirst as string,
+                metrics: paramsOrFirst as string[],
                 resource: rest[0] as string,
                 resourceId: rest[1] as string,
                 interval: rest[2] as string,
@@ -83,7 +83,7 @@ export class Usage {
             };
         }
         
-        const metric = params.metric;
+        const metrics = params.metrics;
         const resource = params.resource;
         const resourceId = params.resourceId;
         const interval = params.interval;
@@ -95,14 +95,14 @@ export class Usage {
         const limit = params.limit;
         const offset = params.offset;
 
-        if (typeof metric === 'undefined') {
-            throw new AppwriteException('Missing required parameter: "metric"');
+        if (typeof metrics === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "metrics"');
         }
 
         const apiPath = '/usage/events';
         const payload: Payload = {};
-        if (typeof metric !== 'undefined') {
-            payload['metric'] = metric;
+        if (typeof metrics !== 'undefined') {
+            payload['metrics'] = metrics;
         }
         if (typeof resource !== 'undefined') {
             payload['resource'] = resource;
@@ -150,19 +150,19 @@ export class Usage {
     }
 
     /**
-     * Aggregate usage gauge snapshots. Gauges are point-in-time values (storage totals, resource counts, …); each group carries the latest snapshot in its interval via `argMax(value, time)`. `metric` is required.
+     * Aggregate usage gauge snapshots. Gauges are point-in-time values (storage totals, resource counts, …); each point carries the latest snapshot in its interval via `argMax(value, time)`. `metrics[]` (1-10) is required; the response always contains one entry per requested metric, each with its own `points[]` time series.
      * 
      * **Two response shapes**:
      * - Omit `interval` for a flat top-N table — `argMax(value, time)` per dimension combination over the whole window, no time axis. Useful for "top 10 resources by current storage".
      * - Pass `interval` (`1m`, `15m`, `30m`, `1h`, `1d`) for a time series — one snapshot per (time bucket × dimension combination).
      * 
-     * `dimensions[]` breaks each row down further — only `resourceId` and `teamId` are supported on gauges. `resourceId` and `teamId` parameters filter the underlying rows. `orderBy=value`+`orderDir=desc`+`limit=N` returns the top-N. When `startAt` is omitted, the default window adapts to interval (or 7d when interval is omitted).
+     * `dimensions[]` breaks each point down further. Supported on gauges: `resourceId`, `teamId`, `service`, `resource`. `service` and `resource` enable per-service / per-resource-type panels (e.g. storage-by-service: group `files.storage`, `deployments.storage`, `builds.storage`, `databases.storage` by `service`). Pass multiple metrics to render stacked charts in one round-trip. `resourceId` and `teamId` parameters filter the underlying rows. `orderBy=value`+`orderDir=desc`+`limit=N` returns the top-N. When `startAt` is omitted, the default window adapts to interval (or 7d when interval is omitted).
      *
-     * @param {string} params.metric - Metric name (required). Example: files.storage, deployments.storage.
+     * @param {string[]} params.metrics - One to ten metric names. Single-metric callers pass a one-element array. Example: `metrics[]=files.storage` or `metrics[]=files.storage&metrics[]=deployments.storage` for stacked charts.
      * @param {string} params.resourceId - Resource id filter.
      * @param {string} params.teamId - Team id filter.
      * @param {string} params.interval - Time interval size. Omit (null) for a flat aggregate over the whole window. Allowed: 1m, 15m, 30m, 1h, 1d.
-     * @param {string[]} params.dimensions - Break-down dimensions. Allowed: resourceId, teamId.
+     * @param {string[]} params.dimensions - Break-down dimensions. Allowed: resourceId, teamId, service, resource.
      * @param {string} params.startAt - Range start in ISO 8601. Defaults to endAt - 7d.
      * @param {string} params.endAt - Range end in ISO 8601. Defaults to the current time.
      * @param {string} params.orderBy - Column to order by. Allowed: time, value. Default time.
@@ -172,21 +172,21 @@ export class Usage {
      * @throws {AppwriteException}
      * @returns {Promise<Models.UsageGaugeList>}
      */
-    listGauges(params: { metric: string, resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number }): Promise<Models.UsageGaugeList>;
+    listGauges(params: { metrics: string[], resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number }): Promise<Models.UsageGaugeList>;
     /**
-     * Aggregate usage gauge snapshots. Gauges are point-in-time values (storage totals, resource counts, …); each group carries the latest snapshot in its interval via `argMax(value, time)`. `metric` is required.
+     * Aggregate usage gauge snapshots. Gauges are point-in-time values (storage totals, resource counts, …); each point carries the latest snapshot in its interval via `argMax(value, time)`. `metrics[]` (1-10) is required; the response always contains one entry per requested metric, each with its own `points[]` time series.
      * 
      * **Two response shapes**:
      * - Omit `interval` for a flat top-N table — `argMax(value, time)` per dimension combination over the whole window, no time axis. Useful for "top 10 resources by current storage".
      * - Pass `interval` (`1m`, `15m`, `30m`, `1h`, `1d`) for a time series — one snapshot per (time bucket × dimension combination).
      * 
-     * `dimensions[]` breaks each row down further — only `resourceId` and `teamId` are supported on gauges. `resourceId` and `teamId` parameters filter the underlying rows. `orderBy=value`+`orderDir=desc`+`limit=N` returns the top-N. When `startAt` is omitted, the default window adapts to interval (or 7d when interval is omitted).
+     * `dimensions[]` breaks each point down further. Supported on gauges: `resourceId`, `teamId`, `service`, `resource`. `service` and `resource` enable per-service / per-resource-type panels (e.g. storage-by-service: group `files.storage`, `deployments.storage`, `builds.storage`, `databases.storage` by `service`). Pass multiple metrics to render stacked charts in one round-trip. `resourceId` and `teamId` parameters filter the underlying rows. `orderBy=value`+`orderDir=desc`+`limit=N` returns the top-N. When `startAt` is omitted, the default window adapts to interval (or 7d when interval is omitted).
      *
-     * @param {string} metric - Metric name (required). Example: files.storage, deployments.storage.
+     * @param {string[]} metrics - One to ten metric names. Single-metric callers pass a one-element array. Example: `metrics[]=files.storage` or `metrics[]=files.storage&metrics[]=deployments.storage` for stacked charts.
      * @param {string} resourceId - Resource id filter.
      * @param {string} teamId - Team id filter.
      * @param {string} interval - Time interval size. Omit (null) for a flat aggregate over the whole window. Allowed: 1m, 15m, 30m, 1h, 1d.
-     * @param {string[]} dimensions - Break-down dimensions. Allowed: resourceId, teamId.
+     * @param {string[]} dimensions - Break-down dimensions. Allowed: resourceId, teamId, service, resource.
      * @param {string} startAt - Range start in ISO 8601. Defaults to endAt - 7d.
      * @param {string} endAt - Range end in ISO 8601. Defaults to the current time.
      * @param {string} orderBy - Column to order by. Allowed: time, value. Default time.
@@ -197,18 +197,18 @@ export class Usage {
      * @returns {Promise<Models.UsageGaugeList>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    listGauges(metric: string, resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number): Promise<Models.UsageGaugeList>;
+    listGauges(metrics: string[], resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number): Promise<Models.UsageGaugeList>;
     listGauges(
-        paramsOrFirst: { metric: string, resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number } | string,
+        paramsOrFirst: { metrics: string[], resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number } | string[],
         ...rest: [(string)?, (string)?, (string)?, (string[])?, (string)?, (string)?, (string)?, (string)?, (number)?, (number)?]    
     ): Promise<Models.UsageGaugeList> {
-        let params: { metric: string, resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number };
+        let params: { metrics: string[], resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { metric: string, resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number };
+            params = (paramsOrFirst || {}) as { metrics: string[], resourceId?: string, teamId?: string, interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number };
         } else {
             params = {
-                metric: paramsOrFirst as string,
+                metrics: paramsOrFirst as string[],
                 resourceId: rest[0] as string,
                 teamId: rest[1] as string,
                 interval: rest[2] as string,
@@ -222,7 +222,7 @@ export class Usage {
             };
         }
         
-        const metric = params.metric;
+        const metrics = params.metrics;
         const resourceId = params.resourceId;
         const teamId = params.teamId;
         const interval = params.interval;
@@ -234,14 +234,14 @@ export class Usage {
         const limit = params.limit;
         const offset = params.offset;
 
-        if (typeof metric === 'undefined') {
-            throw new AppwriteException('Missing required parameter: "metric"');
+        if (typeof metrics === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "metrics"');
         }
 
         const apiPath = '/usage/gauges';
         const payload: Payload = {};
-        if (typeof metric !== 'undefined') {
-            payload['metric'] = metric;
+        if (typeof metrics !== 'undefined') {
+            payload['metrics'] = metrics;
         }
         if (typeof resourceId !== 'undefined') {
             payload['resourceId'] = resourceId;


### PR DESCRIPTION
This PR contains updates to the SDK for version 15.1.0.

## What's Changed

* Breaking: `listEvents` and `listGauges` on `Usage` now take `metrics` (string array, 1-10) instead of a single `metric`
* Breaking: `UsageEventList` and `UsageGaugeList` now expose `interval` and a `metrics` array; `UsageGroup` is replaced by `UsageMetric` and `UsageDataPoint`
* Breaking: `createDatabaseExecution` on `Compute` now posts to the `/executions` endpoint
* Added: `resource` parameter on `Oauth2` `authorize`, `createDeviceAuthorization`, and `createToken` for RFC 8707 resource indicators
* Added: `resources` field on the `Oauth2Authorize` model
* Added: `service` and `resource` break-down dimensions on `Usage` `listGauges`
* Updated: `Databases` transaction and text attribute methods are now marked deprecated in favor of `TablesDB`
* Updated: OAuth2 server fields on the project model are now optional