### PR TITLE
feat: SDK update for version 15.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 15.6.0
+
+* Added: `apps` installation methods `listInstallations`, `getInstallation`, `deleteInstallation`, and `createInstallationToken`
+* Added: `vcs.listNamespaces()` for listing provider namespaces available to an installation
+* Added: `providerNamespace` parameter to `vcs.createRepository()`
+* Added: `listOperations()` on `tablesDB`, `documentsDB`, `vectorsDB`, `mysql`, `postgresql`, and `mongo` for dedicated database lifecycle operations
+* Added: `VcsNamespace`, `VcsNamespaceList`, `DedicatedDatabaseOperation`, and `DedicatedDatabaseOperationList` models
+* Fixed: `activities.listEvents()` takes `queries` as `string[]` instead of `string`
+* Updated: `vcs.listRepositories()` supports `equal` on namespace in queries
+* Updated: `storage.listFiles()` documents `folder` as a filterable attribute
+* Updated: Usage metric docs distinguish an empty `points[]` from a genuine zero value
+
 ## 15.5.0
 
 * Updated: Removed `projects.createDevKey()` method

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { Client, Account } from "@appwrite.io/console";
 To install with a CDN (content delivery network) add the following scripts to the bottom of your <body> tag, but before you use any Appwrite services:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@15.5.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@15.6.0"></script>
 ```
 
 

--- a/docs/examples/apps/create-installation-token.md
+++ b/docs/examples/apps/create-installation-token.md
@@ -1,14 +1,15 @@
 ```javascript
-import { Client, Activities } from "@appwrite.io/console";
+import { Client, Apps } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
     .setProject('<YOUR_PROJECT_ID>'); // Your project ID
 
-const activities = new Activities(client);
+const apps = new Apps(client);
 
-const result = await activities.listEvents({
-    queries: [] // optional
+const result = await apps.createInstallationToken({
+    appId: '<APP_ID>',
+    installationId: '<INSTALLATION_ID>'
 });
 
 console.log(result);

--- a/docs/examples/apps/delete-installation.md
+++ b/docs/examples/apps/delete-installation.md
@@ -1,14 +1,15 @@
 ```javascript
-import { Client, Activities } from "@appwrite.io/console";
+import { Client, Apps } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
     .setProject('<YOUR_PROJECT_ID>'); // Your project ID
 
-const activities = new Activities(client);
+const apps = new Apps(client);
 
-const result = await activities.listEvents({
-    queries: [] // optional
+const result = await apps.deleteInstallation({
+    appId: '<APP_ID>',
+    installationId: '<INSTALLATION_ID>'
 });
 
 console.log(result);

--- a/docs/examples/apps/get-installation.md
+++ b/docs/examples/apps/get-installation.md
@@ -1,14 +1,15 @@
 ```javascript
-import { Client, Activities } from "@appwrite.io/console";
+import { Client, Apps } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
     .setProject('<YOUR_PROJECT_ID>'); // Your project ID
 
-const activities = new Activities(client);
+const apps = new Apps(client);
 
-const result = await activities.listEvents({
-    queries: [] // optional
+const result = await apps.getInstallation({
+    appId: '<APP_ID>',
+    installationId: '<INSTALLATION_ID>'
 });
 
 console.log(result);

--- a/docs/examples/apps/list-installations.md
+++ b/docs/examples/apps/list-installations.md
@@ -1,14 +1,16 @@
 ```javascript
-import { Client, Activities } from "@appwrite.io/console";
+import { Client, Apps } from "@appwrite.io/console";
 
 const client = new Client()
     .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
     .setProject('<YOUR_PROJECT_ID>'); // Your project ID
 
-const activities = new Activities(client);
+const apps = new Apps(client);
 
-const result = await activities.listEvents({
-    queries: [] // optional
+const result = await apps.listInstallations({
+    appId: '<APP_ID>',
+    queries: [], // optional
+    total: false // optional
 });
 
 console.log(result);

--- a/docs/examples/documentsdb/list-operations.md
+++ b/docs/examples/documentsdb/list-operations.md
@@ -1,0 +1,18 @@
+```javascript
+import { Client, DocumentsDB } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const documentsDB = new DocumentsDB(client);
+
+const result = await documentsDB.listOperations({
+    databaseId: '<DATABASE_ID>',
+    status: 'running', // optional
+    limit: 1, // optional
+    offset: 0 // optional
+});
+
+console.log(result);
+```

--- a/docs/examples/mongo/list-operations.md
+++ b/docs/examples/mongo/list-operations.md
@@ -1,0 +1,18 @@
+```javascript
+import { Client, Mongo } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const mongo = new Mongo(client);
+
+const result = await mongo.listOperations({
+    databaseId: '<DATABASE_ID>',
+    status: 'running', // optional
+    limit: 1, // optional
+    offset: 0 // optional
+});
+
+console.log(result);
+```

--- a/docs/examples/mysql/list-operations.md
+++ b/docs/examples/mysql/list-operations.md
@@ -1,0 +1,18 @@
+```javascript
+import { Client, Mysql } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const mysql = new Mysql(client);
+
+const result = await mysql.listOperations({
+    databaseId: '<DATABASE_ID>',
+    status: 'running', // optional
+    limit: 1, // optional
+    offset: 0 // optional
+});
+
+console.log(result);
+```

--- a/docs/examples/postgresql/list-operations.md
+++ b/docs/examples/postgresql/list-operations.md
@@ -1,0 +1,18 @@
+```javascript
+import { Client, Postgresql } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const postgresql = new Postgresql(client);
+
+const result = await postgresql.listOperations({
+    databaseId: '<DATABASE_ID>',
+    status: 'running', // optional
+    limit: 1, // optional
+    offset: 0 // optional
+});
+
+console.log(result);
+```

--- a/docs/examples/tablesdb/list-operations.md
+++ b/docs/examples/tablesdb/list-operations.md
@@ -1,0 +1,18 @@
+```javascript
+import { Client, TablesDB } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const tablesDB = new TablesDB(client);
+
+const result = await tablesDB.listOperations({
+    databaseId: '<DATABASE_ID>',
+    status: 'running', // optional
+    limit: 1, // optional
+    offset: 0 // optional
+});
+
+console.log(result);
+```

--- a/docs/examples/vcs/list-namespaces.md
+++ b/docs/examples/vcs/list-namespaces.md
@@ -7,11 +7,10 @@ const client = new Client()
 
 const vcs = new Vcs(client);
 
-const result = await vcs.createRepository({
+const result = await vcs.listNamespaces({
     installationId: '<INSTALLATION_ID>',
-    name: '<NAME>',
-    xprivate: false,
-    providerNamespace: '<PROVIDER_NAMESPACE>' // optional
+    search: '<SEARCH>', // optional
+    queries: [] // optional
 });
 
 console.log(result);

--- a/docs/examples/vectorsdb/list-operations.md
+++ b/docs/examples/vectorsdb/list-operations.md
@@ -1,0 +1,18 @@
+```javascript
+import { Client, VectorsDB } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const vectorsDB = new VectorsDB(client);
+
+const result = await vectorsDB.listOperations({
+    databaseId: '<DATABASE_ID>',
+    status: 'running', // optional
+    limit: 1, // optional
+    offset: 0 // optional
+});
+
+console.log(result);
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appwrite.io/console",
-  "version": "15.5.0",
+  "version": "15.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appwrite.io/console",
-      "version": "15.5.0",
+      "version": "15.6.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"
@@ -24,6 +24,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "overrides": {
+        "brace-expansion": "5.0.8"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -227,9 +230,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -244,9 +244,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -261,9 +258,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -278,9 +272,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -295,9 +286,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -312,9 +300,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -329,9 +314,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -346,9 +328,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -363,9 +342,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -380,9 +356,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -397,9 +370,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -414,9 +384,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -431,9 +398,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -546,11 +510,14 @@
       "license": "MIT"
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -562,14 +529,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/bytes": {
@@ -586,13 +555,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@appwrite.io/console",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "15.5.0",
+  "version": "15.6.0",
   "license": "BSD-3-Clause",
   "main": "dist/cjs/sdk.js",
   "exports": {
@@ -44,6 +44,9 @@
     "serve-handler": "6.1.7",
     "tslib": "2.8.1",
     "typescript": "5.9.3"
+  },
+  "overrides": {
+    "brace-expansion": "5.0.8"
   },
   "jsdelivr": "dist/iife/sdk.js",
   "unpkg": "dist/iife/sdk.js"

--- a/src/client.ts
+++ b/src/client.ts
@@ -394,7 +394,7 @@ class Client {
         'x-sdk-name': 'Console',
         'x-sdk-platform': 'console',
         'x-sdk-language': 'web',
-        'x-sdk-version': '15.5.0',
+        'x-sdk-version': '15.6.0',
         'X-Appwrite-Response-Format': '1.9.5',
     };
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -388,6 +388,46 @@ export namespace Models {
     }
 
     /**
+     * VcsNamespace
+     */
+    export type VcsNamespace = {
+        /**
+         * VCS (Version Control System) namespace ID.
+         */
+        $id: string;
+        /**
+         * VCS (Version Control System) namespace display name.
+         */
+        name: string;
+        /**
+         * VCS (Version Control System) namespace path, used to filter repositories by namespace.
+         */
+        path: string;
+        /**
+         * Namespace type. Either the user's personal namespace or a group/organization.
+         */
+        type: string;
+        /**
+         * Namespace avatar URL.
+         */
+        avatarUrl: string;
+    }
+
+    /**
+     * VCS Namespaces List
+     */
+    export type VcsNamespaceList = {
+        /**
+         * Total number of namespaces that matched your query.
+         */
+        total: number;
+        /**
+         * List of namespaces.
+         */
+        namespaces: VcsNamespace[];
+    }
+
+    /**
      * Branches List
      */
     export type BranchList = {
@@ -3862,6 +3902,14 @@ export namespace Models {
          * File name.
          */
         name: string;
+        /**
+         * Virtual folder containing the file, with a trailing slash. Empty for the bucket root.
+         */
+        folder: string;
+        /**
+         * Full virtual path of the file: the folder followed by the file name.
+         */
+        key: string;
         /**
          * File MD5 signature.
          */
@@ -8995,6 +9043,10 @@ export namespace Models {
          */
         expiresAt?: string;
         /**
+         * Transaction-log position the backup anchors at, in the engine's own notation: PostgreSQL `{walSegment}|{lsn}`, MySQL and MariaDB `{binlogFile}|{offset}`, MongoDB `{seconds}|{increment}`. Empty when the backup recorded no position, which is the case for backup types that carry none.
+         */
+        logPosition?: string;
+        /**
          * Error message if backup failed.
          */
         error: string;
@@ -10706,6 +10758,70 @@ export namespace Models {
          * Replication lag in seconds.
          */
         lagSeconds: number;
+    }
+
+    /**
+     * Operation
+     */
+    export type DedicatedDatabaseOperation = {
+        /**
+         * Operation ID.
+         */
+        $id: string;
+        /**
+         * Operation creation time in ISO 8601 format.
+         */
+        $createdAt: string;
+        /**
+         * Database ID the operation ran against.
+         */
+        databaseId: string;
+        /**
+         * Operation type, such as provision, update, restore, pausing, resuming, failover, backup-create or cross-region-enable.
+         */
+        type: string;
+        /**
+         * Operation status. Possible values: running (in progress), completed (finished successfully), failed (ended in an error).
+         */
+        status: string;
+        /**
+         * Number of times this operation has been attempted.
+         */
+        attempts: number;
+        /**
+         * Time the operation was requested, in ISO 8601 format.
+         */
+        requestedAt?: string;
+        /**
+         * Time the operation started, in ISO 8601 format.
+         */
+        startedAt?: string;
+        /**
+         * Time the operation reached a terminal state, in ISO 8601 format.
+         */
+        completedAt?: string;
+        /**
+         * Machine-readable failure code. `LockLost` marks an attempt that was fenced and abandoned because another worker took over the database.
+         */
+        errorCode: string;
+        /**
+         * Failure message if the operation failed.
+         */
+        errorMessage: string;
+    }
+
+    /**
+     * OperationList
+     */
+    export type DedicatedDatabaseOperationList = {
+        /**
+         * Total number of operations.
+         */
+        total: number;
+        /**
+         * List of operations.
+         */
+        operations: DedicatedDatabaseOperation[];
     }
 
     /**

--- a/src/services/activities.ts
+++ b/src/services/activities.ts
@@ -13,30 +13,30 @@ export class Activities {
     /**
      * List all events for selected filters.
      *
-     * @param {string} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/databases#querying-documents). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on attributes such as userId, teamId, etc.
+     * @param {string[]} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/databases#querying-documents). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on attributes such as userId, teamId, etc.
      * @throws {AppwriteException}
      * @returns {Promise<Models.ActivityEventList>}
      */
-    listEvents(params?: { queries?: string }): Promise<Models.ActivityEventList>;
+    listEvents(params?: { queries?: string[] }): Promise<Models.ActivityEventList>;
     /**
      * List all events for selected filters.
      *
-     * @param {string} queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/databases#querying-documents). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on attributes such as userId, teamId, etc.
+     * @param {string[]} queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/databases#querying-documents). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on attributes such as userId, teamId, etc.
      * @throws {AppwriteException}
      * @returns {Promise<Models.ActivityEventList>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    listEvents(queries?: string): Promise<Models.ActivityEventList>;
+    listEvents(queries?: string[]): Promise<Models.ActivityEventList>;
     listEvents(
-        paramsOrFirst?: { queries?: string } | string    
+        paramsOrFirst?: { queries?: string[] } | string[]    
     ): Promise<Models.ActivityEventList> {
-        let params: { queries?: string };
+        let params: { queries?: string[] };
         
         if (!paramsOrFirst || (paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { queries?: string };
+            params = (paramsOrFirst || {}) as { queries?: string[] };
         } else {
             params = {
-                queries: paramsOrFirst as string            
+                queries: paramsOrFirst as string[]            
             };
         }
         

--- a/src/services/apps.ts
+++ b/src/services/apps.ts
@@ -610,6 +610,259 @@ export class Apps {
     }
 
     /**
+     * List installations of an application. Requires an app key sent in the `X-Appwrite-Key` header alongside the `X-Appwrite-App` header, or a caller with update access to the app.
+     *
+     * @param {string} params.appId - Application unique ID.
+     * @param {string[]} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long.
+     * @param {boolean} params.total - When set to false, the total count returned will be 0 and will not be calculated.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.AppInstallationList>}
+     */
+    listInstallations(params: { appId: string, queries?: string[], total?: boolean }): Promise<Models.AppInstallationList>;
+    /**
+     * List installations of an application. Requires an app key sent in the `X-Appwrite-Key` header alongside the `X-Appwrite-App` header, or a caller with update access to the app.
+     *
+     * @param {string} appId - Application unique ID.
+     * @param {string[]} queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long.
+     * @param {boolean} total - When set to false, the total count returned will be 0 and will not be calculated.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.AppInstallationList>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    listInstallations(appId: string, queries?: string[], total?: boolean): Promise<Models.AppInstallationList>;
+    listInstallations(
+        paramsOrFirst: { appId: string, queries?: string[], total?: boolean } | string,
+        ...rest: [(string[])?, (boolean)?]    
+    ): Promise<Models.AppInstallationList> {
+        let params: { appId: string, queries?: string[], total?: boolean };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { appId: string, queries?: string[], total?: boolean };
+        } else {
+            params = {
+                appId: paramsOrFirst as string,
+                queries: rest[0] as string[],
+                total: rest[1] as boolean            
+            };
+        }
+        
+        const appId = params.appId;
+        const queries = params.queries;
+        const total = params.total;
+
+        if (typeof appId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "appId"');
+        }
+
+        const apiPath = '/apps/{appId}/installations'.replace('{appId}', encodeURIComponent(String(appId)));
+        const payload: Payload = {};
+        if (typeof queries !== 'undefined') {
+            payload['queries'] = queries;
+        }
+        if (typeof total !== 'undefined') {
+            payload['total'] = total;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
+     * Get an installation of an application by its unique ID. Requires an app key sent in the `X-Appwrite-Key` header alongside the `X-Appwrite-App` header, or a caller with update access to the app.
+     *
+     * @param {string} params.appId - Application unique ID.
+     * @param {string} params.installationId - Installation unique ID.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.AppInstallation>}
+     */
+    getInstallation(params: { appId: string, installationId: string }): Promise<Models.AppInstallation>;
+    /**
+     * Get an installation of an application by its unique ID. Requires an app key sent in the `X-Appwrite-Key` header alongside the `X-Appwrite-App` header, or a caller with update access to the app.
+     *
+     * @param {string} appId - Application unique ID.
+     * @param {string} installationId - Installation unique ID.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.AppInstallation>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    getInstallation(appId: string, installationId: string): Promise<Models.AppInstallation>;
+    getInstallation(
+        paramsOrFirst: { appId: string, installationId: string } | string,
+        ...rest: [(string)?]    
+    ): Promise<Models.AppInstallation> {
+        let params: { appId: string, installationId: string };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { appId: string, installationId: string };
+        } else {
+            params = {
+                appId: paramsOrFirst as string,
+                installationId: rest[0] as string            
+            };
+        }
+        
+        const appId = params.appId;
+        const installationId = params.installationId;
+
+        if (typeof appId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "appId"');
+        }
+        if (typeof installationId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "installationId"');
+        }
+
+        const apiPath = '/apps/{appId}/installations/{installationId}'.replace('{appId}', encodeURIComponent(String(appId))).replace('{installationId}', encodeURIComponent(String(installationId)));
+        const payload: Payload = {};
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
+     * Delete an installation of an application by its unique ID. Requires a caller with update access to the app. Previously issued installation access tokens are revoked.
+     *
+     * @param {string} params.appId - Application unique ID.
+     * @param {string} params.installationId - Installation unique ID.
+     * @throws {AppwriteException}
+     * @returns {Promise<{}>}
+     */
+    deleteInstallation(params: { appId: string, installationId: string }): Promise<{}>;
+    /**
+     * Delete an installation of an application by its unique ID. Requires a caller with update access to the app. Previously issued installation access tokens are revoked.
+     *
+     * @param {string} appId - Application unique ID.
+     * @param {string} installationId - Installation unique ID.
+     * @throws {AppwriteException}
+     * @returns {Promise<{}>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    deleteInstallation(appId: string, installationId: string): Promise<{}>;
+    deleteInstallation(
+        paramsOrFirst: { appId: string, installationId: string } | string,
+        ...rest: [(string)?]    
+    ): Promise<{}> {
+        let params: { appId: string, installationId: string };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { appId: string, installationId: string };
+        } else {
+            params = {
+                appId: paramsOrFirst as string,
+                installationId: rest[0] as string            
+            };
+        }
+        
+        const appId = params.appId;
+        const installationId = params.installationId;
+
+        if (typeof appId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "appId"');
+        }
+        if (typeof installationId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "installationId"');
+        }
+
+        const apiPath = '/apps/{appId}/installations/{installationId}'.replace('{appId}', encodeURIComponent(String(appId))).replace('{installationId}', encodeURIComponent(String(installationId)));
+        const payload: Payload = {};
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'content-type': 'application/json',
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'delete',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
+     * Create a token for an installation of an application. Requires an app key sent in the `X-Appwrite-Key` header alongside the `X-Appwrite-App` header, or a caller with update access to the app. The returned token carries the scopes and authorization details granted to the installation, and can be used as an `Authorization: Bearer` header everywhere OAuth2 access tokens are accepted. Multiple tokens can be active for the same installation at once; each token stays valid until it expires or the installation is updated or deleted.
+     *
+     * @param {string} params.appId - Application unique ID.
+     * @param {string} params.installationId - Installation unique ID.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.Oauth2Token>}
+     */
+    createInstallationToken(params: { appId: string, installationId: string }): Promise<Models.Oauth2Token>;
+    /**
+     * Create a token for an installation of an application. Requires an app key sent in the `X-Appwrite-Key` header alongside the `X-Appwrite-App` header, or a caller with update access to the app. The returned token carries the scopes and authorization details granted to the installation, and can be used as an `Authorization: Bearer` header everywhere OAuth2 access tokens are accepted. Multiple tokens can be active for the same installation at once; each token stays valid until it expires or the installation is updated or deleted.
+     *
+     * @param {string} appId - Application unique ID.
+     * @param {string} installationId - Installation unique ID.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.Oauth2Token>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    createInstallationToken(appId: string, installationId: string): Promise<Models.Oauth2Token>;
+    createInstallationToken(
+        paramsOrFirst: { appId: string, installationId: string } | string,
+        ...rest: [(string)?]    
+    ): Promise<Models.Oauth2Token> {
+        let params: { appId: string, installationId: string };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { appId: string, installationId: string };
+        } else {
+            params = {
+                appId: paramsOrFirst as string,
+                installationId: rest[0] as string            
+            };
+        }
+        
+        const appId = params.appId;
+        const installationId = params.installationId;
+
+        if (typeof appId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "appId"');
+        }
+        if (typeof installationId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "installationId"');
+        }
+
+        const apiPath = '/apps/{appId}/installations/{installationId}/tokens'.replace('{appId}', encodeURIComponent(String(appId))).replace('{installationId}', encodeURIComponent(String(installationId)));
+        const payload: Payload = {};
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'content-type': 'application/json',
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'post',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
      * List app keys for an application.
      *
      * @param {string} params.appId - Application unique ID.

--- a/src/services/documents-db.ts
+++ b/src/services/documents-db.ts
@@ -2466,6 +2466,81 @@ export class DocumentsDB {
     }
 
     /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} params.databaseId - Database ID.
+     * @param {string} params.status - Filter by operation status.
+     * @param {number} params.limit - Maximum number of operations to return.
+     * @param {number} params.offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     */
+    listOperations(params: { databaseId: string, status?: string, limit?: number, offset?: number }): Promise<Models.DedicatedDatabaseOperationList>;
+    /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} databaseId - Database ID.
+     * @param {string} status - Filter by operation status.
+     * @param {number} limit - Maximum number of operations to return.
+     * @param {number} offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    listOperations(databaseId: string, status?: string, limit?: number, offset?: number): Promise<Models.DedicatedDatabaseOperationList>;
+    listOperations(
+        paramsOrFirst: { databaseId: string, status?: string, limit?: number, offset?: number } | string,
+        ...rest: [(string)?, (number)?, (number)?]    
+    ): Promise<Models.DedicatedDatabaseOperationList> {
+        let params: { databaseId: string, status?: string, limit?: number, offset?: number };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { databaseId: string, status?: string, limit?: number, offset?: number };
+        } else {
+            params = {
+                databaseId: paramsOrFirst as string,
+                status: rest[0] as string,
+                limit: rest[1] as number,
+                offset: rest[2] as number            
+            };
+        }
+        
+        const databaseId = params.databaseId;
+        const status = params.status;
+        const limit = params.limit;
+        const offset = params.offset;
+
+        if (typeof databaseId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "databaseId"');
+        }
+
+        const apiPath = '/documentsdb/{databaseId}/operations'.replace('{databaseId}', encodeURIComponent(String(databaseId)));
+        const payload: Payload = {};
+        if (typeof status !== 'undefined') {
+            payload['status'] = status;
+        }
+        if (typeof limit !== 'undefined') {
+            payload['limit'] = limit;
+        }
+        if (typeof offset !== 'undefined') {
+            payload['offset'] = offset;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
      * Get high availability status for a dedicated database. Returns replica statuses, replication lag, and sync mode.
      *
      * @param {string} params.databaseId - Database ID.

--- a/src/services/mongo.ts
+++ b/src/services/mongo.ts
@@ -1763,6 +1763,81 @@ export class Mongo {
     }
 
     /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} params.databaseId - Database ID.
+     * @param {string} params.status - Filter by operation status.
+     * @param {number} params.limit - Maximum number of operations to return.
+     * @param {number} params.offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     */
+    listOperations(params: { databaseId: string, status?: string, limit?: number, offset?: number }): Promise<Models.DedicatedDatabaseOperationList>;
+    /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} databaseId - Database ID.
+     * @param {string} status - Filter by operation status.
+     * @param {number} limit - Maximum number of operations to return.
+     * @param {number} offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    listOperations(databaseId: string, status?: string, limit?: number, offset?: number): Promise<Models.DedicatedDatabaseOperationList>;
+    listOperations(
+        paramsOrFirst: { databaseId: string, status?: string, limit?: number, offset?: number } | string,
+        ...rest: [(string)?, (number)?, (number)?]    
+    ): Promise<Models.DedicatedDatabaseOperationList> {
+        let params: { databaseId: string, status?: string, limit?: number, offset?: number };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { databaseId: string, status?: string, limit?: number, offset?: number };
+        } else {
+            params = {
+                databaseId: paramsOrFirst as string,
+                status: rest[0] as string,
+                limit: rest[1] as number,
+                offset: rest[2] as number            
+            };
+        }
+        
+        const databaseId = params.databaseId;
+        const status = params.status;
+        const limit = params.limit;
+        const offset = params.offset;
+
+        if (typeof databaseId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "databaseId"');
+        }
+
+        const apiPath = '/mongo/{databaseId}/operations'.replace('{databaseId}', encodeURIComponent(String(databaseId)));
+        const payload: Payload = {};
+        if (typeof status !== 'undefined') {
+            payload['status'] = status;
+        }
+        if (typeof limit !== 'undefined') {
+            payload['limit'] = limit;
+        }
+        if (typeof offset !== 'undefined') {
+            payload['offset'] = offset;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
      * Get available point-in-time recovery windows for a dedicated database. Returns the earliest and latest recovery points.
      *
      * @param {string} params.databaseId - Database ID.

--- a/src/services/mysql.ts
+++ b/src/services/mysql.ts
@@ -1842,6 +1842,81 @@ export class Mysql {
     }
 
     /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} params.databaseId - Database ID.
+     * @param {string} params.status - Filter by operation status.
+     * @param {number} params.limit - Maximum number of operations to return.
+     * @param {number} params.offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     */
+    listOperations(params: { databaseId: string, status?: string, limit?: number, offset?: number }): Promise<Models.DedicatedDatabaseOperationList>;
+    /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} databaseId - Database ID.
+     * @param {string} status - Filter by operation status.
+     * @param {number} limit - Maximum number of operations to return.
+     * @param {number} offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    listOperations(databaseId: string, status?: string, limit?: number, offset?: number): Promise<Models.DedicatedDatabaseOperationList>;
+    listOperations(
+        paramsOrFirst: { databaseId: string, status?: string, limit?: number, offset?: number } | string,
+        ...rest: [(string)?, (number)?, (number)?]    
+    ): Promise<Models.DedicatedDatabaseOperationList> {
+        let params: { databaseId: string, status?: string, limit?: number, offset?: number };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { databaseId: string, status?: string, limit?: number, offset?: number };
+        } else {
+            params = {
+                databaseId: paramsOrFirst as string,
+                status: rest[0] as string,
+                limit: rest[1] as number,
+                offset: rest[2] as number            
+            };
+        }
+        
+        const databaseId = params.databaseId;
+        const status = params.status;
+        const limit = params.limit;
+        const offset = params.offset;
+
+        if (typeof databaseId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "databaseId"');
+        }
+
+        const apiPath = '/mysql/{databaseId}/operations'.replace('{databaseId}', encodeURIComponent(String(databaseId)));
+        const payload: Payload = {};
+        if (typeof status !== 'undefined') {
+            payload['status'] = status;
+        }
+        if (typeof limit !== 'undefined') {
+            payload['limit'] = limit;
+        }
+        if (typeof offset !== 'undefined') {
+            payload['offset'] = offset;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
      * Get available point-in-time recovery windows for a dedicated database. Returns the earliest and latest recovery points.
      *
      * @param {string} params.databaseId - Database ID.

--- a/src/services/postgresql.ts
+++ b/src/services/postgresql.ts
@@ -2022,6 +2022,81 @@ export class Postgresql {
     }
 
     /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} params.databaseId - Database ID.
+     * @param {string} params.status - Filter by operation status.
+     * @param {number} params.limit - Maximum number of operations to return.
+     * @param {number} params.offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     */
+    listOperations(params: { databaseId: string, status?: string, limit?: number, offset?: number }): Promise<Models.DedicatedDatabaseOperationList>;
+    /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} databaseId - Database ID.
+     * @param {string} status - Filter by operation status.
+     * @param {number} limit - Maximum number of operations to return.
+     * @param {number} offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    listOperations(databaseId: string, status?: string, limit?: number, offset?: number): Promise<Models.DedicatedDatabaseOperationList>;
+    listOperations(
+        paramsOrFirst: { databaseId: string, status?: string, limit?: number, offset?: number } | string,
+        ...rest: [(string)?, (number)?, (number)?]    
+    ): Promise<Models.DedicatedDatabaseOperationList> {
+        let params: { databaseId: string, status?: string, limit?: number, offset?: number };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { databaseId: string, status?: string, limit?: number, offset?: number };
+        } else {
+            params = {
+                databaseId: paramsOrFirst as string,
+                status: rest[0] as string,
+                limit: rest[1] as number,
+                offset: rest[2] as number            
+            };
+        }
+        
+        const databaseId = params.databaseId;
+        const status = params.status;
+        const limit = params.limit;
+        const offset = params.offset;
+
+        if (typeof databaseId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "databaseId"');
+        }
+
+        const apiPath = '/postgresql/{databaseId}/operations'.replace('{databaseId}', encodeURIComponent(String(databaseId)));
+        const payload: Payload = {};
+        if (typeof status !== 'undefined') {
+            payload['status'] = status;
+        }
+        if (typeof limit !== 'undefined') {
+            payload['limit'] = limit;
+        }
+        if (typeof offset !== 'undefined') {
+            payload['offset'] = offset;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
      * Get available point-in-time recovery windows for a dedicated database. Returns the earliest and latest recovery points.
      *
      * @param {string} params.databaseId - Database ID.

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -450,7 +450,7 @@ export class Storage {
      * Get a list of all the user files. You can use the query params to filter your results.
      *
      * @param {string} params.bucketId - Storage bucket unique ID. You can create a new storage bucket using the Storage service [server integration](https://appwrite.io/docs/server/storage#createBucket).
-     * @param {string[]} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: name, signature, mimeType, sizeOriginal, chunksTotal, chunksUploaded
+     * @param {string[]} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: name, folder, signature, mimeType, sizeOriginal, chunksTotal, chunksUploaded
      * @param {string} params.search - Search term to filter your list results. Max length: 256 chars.
      * @param {boolean} params.total - When set to false, the total count returned will be 0 and will not be calculated.
      * @throws {AppwriteException}
@@ -461,7 +461,7 @@ export class Storage {
      * Get a list of all the user files. You can use the query params to filter your results.
      *
      * @param {string} bucketId - Storage bucket unique ID. You can create a new storage bucket using the Storage service [server integration](https://appwrite.io/docs/server/storage#createBucket).
-     * @param {string[]} queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: name, signature, mimeType, sizeOriginal, chunksTotal, chunksUploaded
+     * @param {string[]} queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Maximum of 100 queries are allowed, each 4096 characters long. You may filter on the following attributes: name, folder, signature, mimeType, sizeOriginal, chunksTotal, chunksUploaded
      * @param {string} search - Search term to filter your list results. Max length: 256 chars.
      * @param {boolean} total - When set to false, the total count returned will be 0 and will not be calculated.
      * @throws {AppwriteException}

--- a/src/services/tables-db.ts
+++ b/src/services/tables-db.ts
@@ -1028,6 +1028,81 @@ export class TablesDB {
     }
 
     /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} params.databaseId - Database ID.
+     * @param {string} params.status - Filter by operation status.
+     * @param {number} params.limit - Maximum number of operations to return.
+     * @param {number} params.offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     */
+    listOperations(params: { databaseId: string, status?: string, limit?: number, offset?: number }): Promise<Models.DedicatedDatabaseOperationList>;
+    /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} databaseId - Database ID.
+     * @param {string} status - Filter by operation status.
+     * @param {number} limit - Maximum number of operations to return.
+     * @param {number} offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    listOperations(databaseId: string, status?: string, limit?: number, offset?: number): Promise<Models.DedicatedDatabaseOperationList>;
+    listOperations(
+        paramsOrFirst: { databaseId: string, status?: string, limit?: number, offset?: number } | string,
+        ...rest: [(string)?, (number)?, (number)?]    
+    ): Promise<Models.DedicatedDatabaseOperationList> {
+        let params: { databaseId: string, status?: string, limit?: number, offset?: number };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { databaseId: string, status?: string, limit?: number, offset?: number };
+        } else {
+            params = {
+                databaseId: paramsOrFirst as string,
+                status: rest[0] as string,
+                limit: rest[1] as number,
+                offset: rest[2] as number            
+            };
+        }
+        
+        const databaseId = params.databaseId;
+        const status = params.status;
+        const limit = params.limit;
+        const offset = params.offset;
+
+        if (typeof databaseId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "databaseId"');
+        }
+
+        const apiPath = '/tablesdb/{databaseId}/operations'.replace('{databaseId}', encodeURIComponent(String(databaseId)));
+        const payload: Payload = {};
+        if (typeof status !== 'undefined') {
+            payload['status'] = status;
+        }
+        if (typeof limit !== 'undefined') {
+            payload['limit'] = limit;
+        }
+        if (typeof offset !== 'undefined') {
+            payload['offset'] = offset;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
      * Get high availability status for a dedicated database. Returns replica statuses, replication lag, and sync mode.
      *
      * @param {string} params.databaseId - Database ID.

--- a/src/services/usage.ts
+++ b/src/services/usage.ts
@@ -145,6 +145,8 @@ export class Usage {
     /**
      * Aggregate usage gauge snapshots. Gauges are point-in-time values (storage totals, resource counts, …); each point carries the latest snapshot in its interval via `argMax(value, time)`. `metrics[]` (1-10) is required; the response always contains one entry per requested metric, each with its own `points[]` time series.
      * 
+     * A metric with no stored samples in the window returns an empty `points[]`. A metric that really did read zero returns a point whose `value` is `0`, so "no such series" and "a genuine zero" are different answers.
+     * 
      * **Two response shapes**:
      * - Omit `interval` for a flat top-N table — `argMax(value, time)` per dimension combination over the whole window, no time axis. Useful for "top 10 resources by current storage".
      * - Pass `interval` (`1m`, `15m`, `30m`, `1h`, `1d`) for a time series — one snapshot per (time bucket × dimension combination).
@@ -167,6 +169,8 @@ export class Usage {
     listGauges(params: { metrics: string[], queries?: string[], interval?: string, dimensions?: string[], startAt?: string, endAt?: string, orderBy?: string, orderDir?: string, limit?: number, offset?: number }): Promise<Models.UsageGaugeList>;
     /**
      * Aggregate usage gauge snapshots. Gauges are point-in-time values (storage totals, resource counts, …); each point carries the latest snapshot in its interval via `argMax(value, time)`. `metrics[]` (1-10) is required; the response always contains one entry per requested metric, each with its own `points[]` time series.
+     * 
+     * A metric with no stored samples in the window returns an empty `points[]`. A metric that really did read zero returns a point whose `value` is `0`, so "no such series" and "a genuine zero" are different answers.
      * 
      * **Two response shapes**:
      * - Omit `interval` for a flat top-N table — `argMax(value, time)` per dimension combination over the whole window, no time axis. Useful for "top 10 resources by current storage".

--- a/src/services/vcs.ts
+++ b/src/services/vcs.ts
@@ -99,7 +99,7 @@ export class Vcs {
      * @param {string} params.installationId - Installation Id
      * @param {VCSDetectionType} params.type - Detector type. Must be one of the following: runtime, framework
      * @param {string} params.search - Search term to filter your list results. Max length: 256 chars.
-     * @param {string[]} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset
+     * @param {string[]} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit, offset, and equal on namespace.
      * @throws {AppwriteException}
      * @returns {Promise<Models.ProviderRepositoryRuntimeList | Models.ProviderRepositoryFrameworkList>}
      */
@@ -110,7 +110,7 @@ export class Vcs {
      * @param {string} installationId - Installation Id
      * @param {VCSDetectionType} type - Detector type. Must be one of the following: runtime, framework
      * @param {string} search - Search term to filter your list results. Max length: 256 chars.
-     * @param {string[]} queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset
+     * @param {string[]} queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit, offset, and equal on namespace.
      * @throws {AppwriteException}
      * @returns {Promise<Models.ProviderRepositoryRuntimeList | Models.ProviderRepositoryFrameworkList>}
      * @deprecated Use the object parameter style method for a better developer experience.
@@ -177,40 +177,44 @@ export class Vcs {
      * @param {string} params.installationId - Installation Id
      * @param {string} params.name - Repository name (slug)
      * @param {boolean} params.xprivate - Mark repository public or private
+     * @param {string} params.providerNamespace - Namespace of the git repository. Defaults to the installation's own namespace.
      * @throws {AppwriteException}
      * @returns {Promise<Models.ProviderRepository>}
      */
-    createRepository(params: { installationId: string, name: string, xprivate: boolean }): Promise<Models.ProviderRepository>;
+    createRepository(params: { installationId: string, name: string, xprivate: boolean, providerNamespace?: string }): Promise<Models.ProviderRepository>;
     /**
      * Create a new GitHub repository through your installation. This endpoint allows you to create either a public or private repository by specifying a name and visibility setting. The repository will be created under your GitHub user account or organization, depending on your installation type. The GitHub installation must be properly configured and have the necessary permissions for repository creation.
      *
      * @param {string} installationId - Installation Id
      * @param {string} name - Repository name (slug)
      * @param {boolean} xprivate - Mark repository public or private
+     * @param {string} providerNamespace - Namespace of the git repository. Defaults to the installation's own namespace.
      * @throws {AppwriteException}
      * @returns {Promise<Models.ProviderRepository>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    createRepository(installationId: string, name: string, xprivate: boolean): Promise<Models.ProviderRepository>;
+    createRepository(installationId: string, name: string, xprivate: boolean, providerNamespace?: string): Promise<Models.ProviderRepository>;
     createRepository(
-        paramsOrFirst: { installationId: string, name: string, xprivate: boolean } | string,
-        ...rest: [(string)?, (boolean)?]    
+        paramsOrFirst: { installationId: string, name: string, xprivate: boolean, providerNamespace?: string } | string,
+        ...rest: [(string)?, (boolean)?, (string)?]    
     ): Promise<Models.ProviderRepository> {
-        let params: { installationId: string, name: string, xprivate: boolean };
+        let params: { installationId: string, name: string, xprivate: boolean, providerNamespace?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { installationId: string, name: string, xprivate: boolean };
+            params = (paramsOrFirst || {}) as { installationId: string, name: string, xprivate: boolean, providerNamespace?: string };
         } else {
             params = {
                 installationId: paramsOrFirst as string,
                 name: rest[0] as string,
-                xprivate: rest[1] as boolean            
+                xprivate: rest[1] as boolean,
+                providerNamespace: rest[2] as string            
             };
         }
         
         const installationId = params.installationId;
         const name = params.name;
         const xprivate = params.xprivate;
+        const providerNamespace = params.providerNamespace;
 
         if (typeof installationId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "installationId"');
@@ -229,6 +233,9 @@ export class Vcs {
         }
         if (typeof xprivate !== 'undefined') {
             payload['private'] = xprivate;
+        }
+        if (typeof providerNamespace !== 'undefined') {
+            payload['providerNamespace'] = providerNamespace;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
@@ -701,6 +708,74 @@ export class Vcs {
 
         return this.client.call(
             'delete',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
+     * List provider namespaces available to a VCS installation. This can include the user personal namespace and any groups or organizations the installation can browse.
+     *
+     * @param {string} params.installationId - Installation Id
+     * @param {string} params.search - Search term to filter your list results. Max length: 256 chars.
+     * @param {string[]} params.queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.VcsNamespaceList>}
+     */
+    listNamespaces(params: { installationId: string, search?: string, queries?: string[] }): Promise<Models.VcsNamespaceList>;
+    /**
+     * List provider namespaces available to a VCS installation. This can include the user personal namespace and any groups or organizations the installation can browse.
+     *
+     * @param {string} installationId - Installation Id
+     * @param {string} search - Search term to filter your list results. Max length: 256 chars.
+     * @param {string[]} queries - Array of query strings generated using the Query class provided by the SDK. [Learn more about queries](https://appwrite.io/docs/queries). Only supported methods are limit and offset
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.VcsNamespaceList>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    listNamespaces(installationId: string, search?: string, queries?: string[]): Promise<Models.VcsNamespaceList>;
+    listNamespaces(
+        paramsOrFirst: { installationId: string, search?: string, queries?: string[] } | string,
+        ...rest: [(string)?, (string[])?]    
+    ): Promise<Models.VcsNamespaceList> {
+        let params: { installationId: string, search?: string, queries?: string[] };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { installationId: string, search?: string, queries?: string[] };
+        } else {
+            params = {
+                installationId: paramsOrFirst as string,
+                search: rest[0] as string,
+                queries: rest[1] as string[]            
+            };
+        }
+        
+        const installationId = params.installationId;
+        const search = params.search;
+        const queries = params.queries;
+
+        if (typeof installationId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "installationId"');
+        }
+
+        const apiPath = '/vcs/installations/{installationId}/namespaces'.replace('{installationId}', encodeURIComponent(String(installationId)));
+        const payload: Payload = {};
+        if (typeof search !== 'undefined') {
+            payload['search'] = search;
+        }
+        if (typeof queries !== 'undefined') {
+            payload['queries'] = queries;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
             uri,
             apiHeaders,
             payload

--- a/src/services/vectors-db.ts
+++ b/src/services/vectors-db.ts
@@ -2490,6 +2490,81 @@ export class VectorsDB {
     }
 
     /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} params.databaseId - Database ID.
+     * @param {string} params.status - Filter by operation status.
+     * @param {number} params.limit - Maximum number of operations to return.
+     * @param {number} params.offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     */
+    listOperations(params: { databaseId: string, status?: string, limit?: number, offset?: number }): Promise<Models.DedicatedDatabaseOperationList>;
+    /**
+     * List the lifecycle operations recorded for a dedicated database, newest first. Every provision, update, restore, backup and replication action is recorded here with its outcome, including an attempt that was abandoned because another worker took over the database.
+     *
+     * @param {string} databaseId - Database ID.
+     * @param {string} status - Filter by operation status.
+     * @param {number} limit - Maximum number of operations to return.
+     * @param {number} offset - Number of operations to skip.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.DedicatedDatabaseOperationList>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    listOperations(databaseId: string, status?: string, limit?: number, offset?: number): Promise<Models.DedicatedDatabaseOperationList>;
+    listOperations(
+        paramsOrFirst: { databaseId: string, status?: string, limit?: number, offset?: number } | string,
+        ...rest: [(string)?, (number)?, (number)?]    
+    ): Promise<Models.DedicatedDatabaseOperationList> {
+        let params: { databaseId: string, status?: string, limit?: number, offset?: number };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { databaseId: string, status?: string, limit?: number, offset?: number };
+        } else {
+            params = {
+                databaseId: paramsOrFirst as string,
+                status: rest[0] as string,
+                limit: rest[1] as number,
+                offset: rest[2] as number            
+            };
+        }
+        
+        const databaseId = params.databaseId;
+        const status = params.status;
+        const limit = params.limit;
+        const offset = params.offset;
+
+        if (typeof databaseId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "databaseId"');
+        }
+
+        const apiPath = '/vectorsdb/{databaseId}/operations'.replace('{databaseId}', encodeURIComponent(String(databaseId)));
+        const payload: Payload = {};
+        if (typeof status !== 'undefined') {
+            payload['status'] = status;
+        }
+        if (typeof limit !== 'undefined') {
+            payload['limit'] = limit;
+        }
+        if (typeof offset !== 'undefined') {
+            payload['offset'] = offset;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'get',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
      * Get high availability status for a dedicated database. Returns replica statuses, replication lag, and sync mode.
      *
      * @param {string} params.databaseId - Database ID.


### PR DESCRIPTION
This PR contains updates to the SDK for version 15.6.0.

## What's Changed

* Added: `apps` installation methods `listInstallations`, `getInstallation`, `deleteInstallation`, and `createInstallationToken`
* Added: `vcs.listNamespaces()` for listing provider namespaces available to an installation
* Added: `providerNamespace` parameter to `vcs.createRepository()`
* Added: `listOperations()` on `tablesDB`, `documentsDB`, `vectorsDB`, `mysql`, `postgresql`, and `mongo` for dedicated database lifecycle operations
* Added: `VcsNamespace`, `VcsNamespaceList`, `DedicatedDatabaseOperation`, and `DedicatedDatabaseOperationList` models
* Fixed: `activities.listEvents()` takes `queries` as `string[]` instead of `string`
* Updated: `vcs.listRepositories()` supports `equal` on namespace in queries
* Updated: `storage.listFiles()` documents `folder` as a filterable attribute
* Updated: Usage metric docs distinguish an empty `points[]` from a genuine zero value

## Notes for reviewers

**`activities.listEvents()` signature change.** `queries` goes from `string` to `string[]`. The old type was simply wrong — the endpoint has always taken an array server-side, so any caller passing a string was already getting a rejected request. No working code breaks; only code that could not have worked stops compiling. It is typed as a fix rather than a breaking change, consistent with 15.3.0–15.5.0 shipping outright method removals under minor bumps.

**Blocks the CLI release.** appwrite/sdk-for-cli#346 (v23.2.0) currently fails `tsc` because it calls `listInstallations`, `getInstallation`, `deleteInstallation`, `createInstallationToken`, `listOperations`, `listNamespaces`, the 4-argument `createRepository`, and the array-typed `listEvents` — none of which exist in `@appwrite.io/console@15.5.0`. This release supplies all of them, and needs to be published to npm before the CLI can build.
