### PR TITLE
feat: Console SDK update for version 15.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 15.7.0
+
+* Added: `waf.createChallengeRule()` and `waf.updateChallengeRule()` for managing challenge rules
+* Added: `WafRuleChallenge` model
+* Added: `specification` parameter to `update()` on `tablesDB`, `documentsDB`, and `vectorsDB`
+* Added: `folder` parameter to `storage.createFile()` for placing files in virtual folders
+* Updated: `backups.createRestoration()` documents in-place restores when `newResourceId` is omitted
+
 ## 15.6.0
 
 * Added: `apps` installation methods `listInstallations`, `getInstallation`, `deleteInstallation`, and `createInstallationToken`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Change Log
 
+## 15.8.0
+
+* Breaking: `create()` on `mysql`, `postgresql`, and `mongo` no longer accepts `api`
+* Breaking: `project.updateSessionLimitPolicy()` now requires `total`
+* Added: `syncMode` parameter to `create()` and `update()` on `tablesDB`, `documentsDB`, and `vectorsDB`
+* Added: `difficulty` and `ttl` parameters to `waf.createChallengeRule()` and `waf.updateChallengeRule()`
+* Added: `key` parameter to `waf.createRateLimitRule()` and `waf.updateRateLimitRule()`
+* Added: replication sync state fields to `DatabaseStatus` and `DedicatedDatabaseReplicas`
+* Added: `syncMode` to the `DedicatedDatabase` model
+* Added: `difficulty` and `ttl` to `WafRuleChallenge`, and `key` to `WafRuleRateLimit`
+* Added: `requestedType` and `fallbackReason` to `DedicatedDatabaseBackup`
+* Added: `attempt` and `lastError` to `DatabaseMigration`
+* Added: `node-26` to the `Runtime` and `BuildRuntime` enums
+* Updated: `DatabaseStatusReplica.role` documents the `unknown` role during topology transitions
+* Updated: Project policy limits for password history, session duration, session count, and users
+
 ## 15.7.0
 
 * Added: `waf.createChallengeRule()` and `waf.updateChallengeRule()` for managing challenge rules

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { Client, Account } from "@appwrite.io/console";
 To install with a CDN (content delivery network) add the following scripts to the bottom of your <body> tag, but before you use any Appwrite services:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@15.6.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@15.7.0"></script>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ import { Client, Account } from "@appwrite.io/console";
 To install with a CDN (content delivery network) add the following scripts to the bottom of your <body> tag, but before you use any Appwrite services:
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@15.7.0"></script>
+<script src="https://cdn.jsdelivr.net/npm/@appwrite.io/console@15.8.0"></script>
 ```
 
 

--- a/docs/examples/documentsdb/create.md
+++ b/docs/examples/documentsdb/create.md
@@ -12,7 +12,8 @@ const result = await documentsDB.create({
     name: '<NAME>',
     enabled: false, // optional
     specification: 'serverless', // optional
-    replicas: 0 // optional
+    replicas: 0, // optional
+    syncMode: 'async' // optional
 });
 
 console.log(result);

--- a/docs/examples/documentsdb/update.md
+++ b/docs/examples/documentsdb/update.md
@@ -11,6 +11,7 @@ const result = await documentsDB.update({
     databaseId: '<DATABASE_ID>',
     name: '<NAME>',
     enabled: false, // optional
+    specification: 'serverless', // optional
     replicas: 0 // optional
 });
 

--- a/docs/examples/documentsdb/update.md
+++ b/docs/examples/documentsdb/update.md
@@ -12,7 +12,8 @@ const result = await documentsDB.update({
     name: '<NAME>',
     enabled: false, // optional
     specification: 'serverless', // optional
-    replicas: 0 // optional
+    replicas: 0, // optional
+    syncMode: 'async' // optional
 });
 
 console.log(result);

--- a/docs/examples/mongo/create.md
+++ b/docs/examples/mongo/create.md
@@ -22,8 +22,7 @@ const result = await mongo.create({
     pitrRetentionDays: 1, // optional
     storageAutoscaling: false, // optional
     storageAutoscalingThresholdPercent: 50, // optional
-    storageAutoscalingMaxGb: 0, // optional
-    api: 'tablesdb' // optional
+    storageAutoscalingMaxGb: 0 // optional
 });
 
 console.log(result);

--- a/docs/examples/mysql/create.md
+++ b/docs/examples/mysql/create.md
@@ -22,8 +22,7 @@ const result = await mysql.create({
     pitrRetentionDays: 1, // optional
     storageAutoscaling: false, // optional
     storageAutoscalingThresholdPercent: 50, // optional
-    storageAutoscalingMaxGb: 0, // optional
-    api: 'tablesdb' // optional
+    storageAutoscalingMaxGb: 0 // optional
 });
 
 console.log(result);

--- a/docs/examples/postgresql/create.md
+++ b/docs/examples/postgresql/create.md
@@ -22,8 +22,7 @@ const result = await postgresql.create({
     pitrRetentionDays: 1, // optional
     storageAutoscaling: false, // optional
     storageAutoscalingThresholdPercent: 50, // optional
-    storageAutoscalingMaxGb: 0, // optional
-    api: 'tablesdb' // optional
+    storageAutoscalingMaxGb: 0 // optional
 });
 
 console.log(result);

--- a/docs/examples/project/update-session-duration-policy.md
+++ b/docs/examples/project/update-session-duration-policy.md
@@ -8,7 +8,7 @@ const client = new Client()
 const project = new Project(client);
 
 const result = await project.updateSessionDurationPolicy({
-    duration: 5
+    duration: 60
 });
 
 console.log(result);

--- a/docs/examples/project/update-user-limit-policy.md
+++ b/docs/examples/project/update-user-limit-policy.md
@@ -8,7 +8,7 @@ const client = new Client()
 const project = new Project(client);
 
 const result = await project.updateUserLimitPolicy({
-    total: 1
+    total: 0
 });
 
 console.log(result);

--- a/docs/examples/storage/create-file.md
+++ b/docs/examples/storage/create-file.md
@@ -11,7 +11,8 @@ const result = await storage.createFile({
     bucketId: '<BUCKET_ID>',
     fileId: '<FILE_ID>',
     file: document.getElementById('uploader').files[0],
-    permissions: [Permission.read(Role.any())] // optional
+    permissions: [Permission.read(Role.any())], // optional
+    folder: '' // optional
 });
 
 console.log(result);

--- a/docs/examples/tablesdb/create.md
+++ b/docs/examples/tablesdb/create.md
@@ -12,7 +12,8 @@ const result = await tablesDB.create({
     name: '<NAME>',
     enabled: false, // optional
     specification: 'serverless', // optional
-    replicas: 0 // optional
+    replicas: 0, // optional
+    syncMode: 'async' // optional
 });
 
 console.log(result);

--- a/docs/examples/tablesdb/update.md
+++ b/docs/examples/tablesdb/update.md
@@ -11,6 +11,7 @@ const result = await tablesDB.update({
     databaseId: '<DATABASE_ID>',
     name: '<NAME>', // optional
     enabled: false, // optional
+    specification: 'serverless', // optional
     replicas: 0 // optional
 });
 

--- a/docs/examples/tablesdb/update.md
+++ b/docs/examples/tablesdb/update.md
@@ -12,7 +12,8 @@ const result = await tablesDB.update({
     name: '<NAME>', // optional
     enabled: false, // optional
     specification: 'serverless', // optional
-    replicas: 0 // optional
+    replicas: 0, // optional
+    syncMode: 'async' // optional
 });
 
 console.log(result);

--- a/docs/examples/vectorsdb/create.md
+++ b/docs/examples/vectorsdb/create.md
@@ -12,7 +12,8 @@ const result = await vectorsDB.create({
     name: '<NAME>',
     enabled: false, // optional
     specification: 'serverless', // optional
-    replicas: 0 // optional
+    replicas: 0, // optional
+    syncMode: 'async' // optional
 });
 
 console.log(result);

--- a/docs/examples/vectorsdb/update.md
+++ b/docs/examples/vectorsdb/update.md
@@ -11,6 +11,7 @@ const result = await vectorsDB.update({
     databaseId: '<DATABASE_ID>',
     name: '<NAME>',
     enabled: false, // optional
+    specification: 'serverless', // optional
     replicas: 0 // optional
 });
 

--- a/docs/examples/vectorsdb/update.md
+++ b/docs/examples/vectorsdb/update.md
@@ -12,7 +12,8 @@ const result = await vectorsDB.update({
     name: '<NAME>',
     enabled: false, // optional
     specification: 'serverless', // optional
-    replicas: 0 // optional
+    replicas: 0, // optional
+    syncMode: 'async' // optional
 });
 
 console.log(result);

--- a/docs/examples/waf/create-challenge-rule.md
+++ b/docs/examples/waf/create-challenge-rule.md
@@ -16,7 +16,9 @@ const result = await waf.createChallengeRule({
     challengeType: 'compute', // optional
     priority: -100000, // optional
     enabled: false, // optional
-    conditions: '' // optional
+    conditions: '', // optional
+    difficulty: 1, // optional
+    ttl: 900 // optional
 });
 
 console.log(result);

--- a/docs/examples/waf/create-challenge-rule.md
+++ b/docs/examples/waf/create-challenge-rule.md
@@ -1,0 +1,23 @@
+```javascript
+import { Client, Waf } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const waf = new Waf(client);
+
+const result = await waf.createChallengeRule({
+    ruleId: '<RULE_ID>',
+    resourceType: 'api',
+    name: '<NAME>',
+    resourceId: '<RESOURCE_ID>', // optional
+    description: '<DESCRIPTION>', // optional
+    challengeType: 'compute', // optional
+    priority: -100000, // optional
+    enabled: false, // optional
+    conditions: '' // optional
+});
+
+console.log(result);
+```

--- a/docs/examples/waf/create-rate-limit-rule.md
+++ b/docs/examples/waf/create-rate-limit-rule.md
@@ -15,6 +15,7 @@ const result = await waf.createRateLimitRule({
     interval: 1,
     resourceId: '<RESOURCE_ID>', // optional
     description: '<DESCRIPTION>', // optional
+    key: 'ip', // optional
     priority: -100000, // optional
     enabled: false, // optional
     conditions: '' // optional

--- a/docs/examples/waf/update-challenge-rule.md
+++ b/docs/examples/waf/update-challenge-rule.md
@@ -1,0 +1,23 @@
+```javascript
+import { Client, Waf } from "@appwrite.io/console";
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1') // Your API Endpoint
+    .setProject('<YOUR_PROJECT_ID>'); // Your project ID
+
+const waf = new Waf(client);
+
+const result = await waf.updateChallengeRule({
+    ruleId: '<RULE_ID>',
+    resourceType: 'api', // optional
+    resourceId: '<RESOURCE_ID>', // optional
+    name: '<NAME>', // optional
+    description: '<DESCRIPTION>', // optional
+    challengeType: 'compute', // optional
+    priority: -100000, // optional
+    enabled: false, // optional
+    conditions: '' // optional
+});
+
+console.log(result);
+```

--- a/docs/examples/waf/update-challenge-rule.md
+++ b/docs/examples/waf/update-challenge-rule.md
@@ -16,7 +16,9 @@ const result = await waf.updateChallengeRule({
     challengeType: 'compute', // optional
     priority: -100000, // optional
     enabled: false, // optional
-    conditions: '' // optional
+    conditions: '', // optional
+    difficulty: 1, // optional
+    ttl: 900 // optional
 });
 
 console.log(result);

--- a/docs/examples/waf/update-rate-limit-rule.md
+++ b/docs/examples/waf/update-rate-limit-rule.md
@@ -15,6 +15,7 @@ const result = await waf.updateRateLimitRule({
     description: '<DESCRIPTION>', // optional
     limit: 1, // optional
     interval: 1, // optional
+    key: 'ip', // optional
     priority: -100000, // optional
     enabled: false, // optional
     conditions: '' // optional

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@rollup/plugin-typescript": "12.3.0",
         "@types/json-bigint": "1.0.4",
         "playwright": "1.56.1",
-        "rollup": "4.62.2",
+        "rollup": "4.62.3",
         "serve-handler": "6.1.7",
         "tslib": "2.8.1",
         "typescript": "5.9.3"
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.3.tgz",
+      "integrity": "sha512-c0wdcekXtQvvn5Tsrk/+op/gUArrbWaFduBnTLP2l1cKLSQs4diMWjJw3m6A0DdzT8dAAX95KpkJ3qynCePbmw==",
       "cpu": [
         "arm"
       ],
@@ -153,9 +153,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.3.tgz",
+      "integrity": "sha512-3YjElDdWN+qXAFbJ/CzPV+0wspLqh54k/I6GfdYtEJRqg7buSgc1yPM3B+93j1M4neobtkATHZTmxK2AMVGfnA==",
       "cpu": [
         "arm64"
       ],
@@ -167,9 +167,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.3.tgz",
+      "integrity": "sha512-Pch2pFNOxxz1hTjypIdPyRTR6riiwRl84+VcN9djS680fw+Co1nAJINrdpqp7KV0NvyuU8ilZXZCjd7ykJl1GQ==",
       "cpu": [
         "arm64"
       ],
@@ -181,9 +181,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.3.tgz",
+      "integrity": "sha512-LEuncFUHFiF8t4yZVZvvZA1wk0pjAscRnsrn1EfTEmN4HXotBi2YtcnLRyaK6UbuczW7xZS5ES+81Rdz8Z0T6g==",
       "cpu": [
         "x64"
       ],
@@ -195,9 +195,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.3.tgz",
+      "integrity": "sha512-zvBUvsQUpOWALdDsk6qbS8bXf2VxmPisuudNDrY7x0p0jBdsoZl8HsHczIOgkQiZldmcacMKtBzpoGVNeIe2bQ==",
       "cpu": [
         "arm64"
       ],
@@ -209,9 +209,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.3.tgz",
+      "integrity": "sha512-C2KmNrcSem/AMg984H/dev+si0lieQGdXdR/lYGJnuumXnFb9Y7QdiI62obFdLlxRYLBv4P0eUVIDbD4c1vVvw==",
       "cpu": [
         "x64"
       ],
@@ -223,13 +223,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.3.tgz",
+      "integrity": "sha512-ggXnsTAEzNQx74XpunRsiZ9aBZDsI7XIa0hm2nzR9f4WzH5/f/d73ZSDaC5ejJ8YLY4NW+V3wr0tjOaeCq8hqA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -237,13 +240,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.3.tgz",
+      "integrity": "sha512-2vng+FlzNUhKZxtej3IUqJgbZoQk2M/dwQM20+ULV0R/E/8tr9/P6uEf2iiGIk4HL0zMKh5Jry7mUHdUOvyGgA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -251,13 +257,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.3.tgz",
+      "integrity": "sha512-LLLFZKt4/Nraf9rxDkhiU8QVgLF4WmCkfr0L4fj0fPfIZFBib0DeiFk1hhaYKd03LFAFJcxHslhDFlNJLylf5Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -265,13 +274,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.3.tgz",
+      "integrity": "sha512-WJkdQCvS9sWNOUBJZfQRKpZGFBztRzcowI+nndmflKgU4XY+3a420FgTOSKTsVqJbnzSxeT4vaJalpOaPo2YCQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -279,13 +291,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.3.tgz",
+      "integrity": "sha512-PwHXCCS2n64/1Ot6rP1YEYA02MGYBcQlr8CSZZyrUG2O7NH6NklYmvr9v3Jy+5e/eDeNchc/ukmKJi9LuflMIQ==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -293,13 +308,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.3.tgz",
+      "integrity": "sha512-vUjxINQu3RC8NZS3ykk1gN65gIz8pAopOq2HXuZhiIxHdx7TFvDG+jgrdSgInu1Eza4/Rfi2VzZgyIgEH4WOaw==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -307,13 +325,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.3.tgz",
+      "integrity": "sha512-wzko4aJ13+0G3kGnviCg5gnXFKd40izKsrf2uOw12US4XqprkDrmwOpeW14aSNa37V8bfPcz5Fkob6LZ3BAPmA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -321,13 +342,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.3.tgz",
+      "integrity": "sha512-8120ue0JUMSwy11stlwnfdX3pPd+WZYGCDBwEHWtIHi6pOpZmsEF5QKB7a/UN+XFdqvobxz98kv8RTqikyCEBw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -335,13 +359,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.3.tgz",
+      "integrity": "sha512-XLFHnR3tXMjbOCh2vtVJHmxt+995uJsTERQyseFDRA0xxMxyTZPLa3OIUlyFaO4mF/Lu0FjmWHCuPXJT1n/IOg==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -349,13 +376,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.3.tgz",
+      "integrity": "sha512-se6yXvNGMIl0f+RQzyh7XAmia8/9kplQx424wnG2w0C1oi6XgO6Y8otKhdXFHbHs88Ihavzmvh1NWjuovE76BQ==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -363,13 +393,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.3.tgz",
+      "integrity": "sha512-gNoxRefktVIiGflpONuxWWXZAzIQG++z9qHO3xKwk4WdDMuQja3JHGfE1u0i3PfPDyvhypdk+WrgIJqLhGG7sg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -377,13 +410,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-V4KtWtQfAFMU7+9/A/VDps/VI8CHd3cYz0L8sgJzz8qK7eY7wI4ruFD82UYIYvW9Z4DtlTfhQcsl4XyPHW5uSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -391,13 +427,16 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.3.tgz",
+      "integrity": "sha512-LBx9LYXvj2CBkMkjLdNAWLwH0MLMin7do2VcVo9kVPibGLkY0BQQut2fv7NVqkXqZ/CrAu9LqDHVV1xHCMpCPw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -405,9 +444,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.3.tgz",
+      "integrity": "sha512-ABVf3Q0RCu7NcyCCOZQI0pJ3GuSdfSl8EXcy88QtdceIMIoCUdfhsJChZ64L9zVM2aJHjde1Bhn5uqSRcX9ySA==",
       "cpu": [
         "x64"
       ],
@@ -419,9 +458,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.3.tgz",
+      "integrity": "sha512-+2Cy/ldweGBLlPIKsQLF8U5N44a0KDdbrk1rAjHOM9M2K+kGdIVjHLmmrZIcx+9Ny3ke/1JomCsDI1ocb11+sg==",
       "cpu": [
         "arm64"
       ],
@@ -433,9 +472,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.3.tgz",
+      "integrity": "sha512-dtZvzc8BedpSaFNy75x6uiWwAGTH+aZHDtdrqP6qk+WcLJrfti6sGje1ZJ9UxyzDLF23d/mV+PaMwuC0hL7UVA==",
       "cpu": [
         "arm64"
       ],
@@ -447,9 +486,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.3.tgz",
+      "integrity": "sha512-Rj8Ra4noo+aYy7sKBggCx0407mws34kAb1ySyWuq5DAtFBQdkSwnsjCgPrhPe9cvgBKZIukpE+CVHvORCS93kQ==",
       "cpu": [
         "ia32"
       ],
@@ -461,9 +500,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.3.tgz",
+      "integrity": "sha512-vp7N084ew/odXn2gi/mzm9mUkQu9l6AiN6dt4IeUM2Uvm9o+cVmP+YkqbMOteLbiGgqBBlJZjIMYVCfOOIVbVQ==",
       "cpu": [
         "x64"
       ],
@@ -475,9 +514,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.3.tgz",
+      "integrity": "sha512-MOG/3gTOn4Fwf574RVOaY61I5o6P90legkFADiTyn1hyjNydT+cerU2rLUwPdZkKKyJ+iT+K9p7WXK4LM1Ka6g==",
       "cpu": [
         "x64"
       ],
@@ -838,9 +877,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "version": "4.62.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.3.tgz",
+      "integrity": "sha512-Gu0c0iH9FzgX1L1t7ByIbbS3Vmdz+6KHm/EsqmmC71gUQ82yvZRkTK6XzrFObSka91WUVdynqp6nsfilzr5k6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -854,31 +893,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.2",
-        "@rollup/rollup-android-arm64": "4.62.2",
-        "@rollup/rollup-darwin-arm64": "4.62.2",
-        "@rollup/rollup-darwin-x64": "4.62.2",
-        "@rollup/rollup-freebsd-arm64": "4.62.2",
-        "@rollup/rollup-freebsd-x64": "4.62.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-        "@rollup/rollup-linux-loong64-musl": "4.62.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-musl": "4.62.2",
-        "@rollup/rollup-openbsd-x64": "4.62.2",
-        "@rollup/rollup-openharmony-arm64": "4.62.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-        "@rollup/rollup-win32-x64-gnu": "4.62.2",
-        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "@rollup/rollup-android-arm-eabi": "4.62.3",
+        "@rollup/rollup-android-arm64": "4.62.3",
+        "@rollup/rollup-darwin-arm64": "4.62.3",
+        "@rollup/rollup-darwin-x64": "4.62.3",
+        "@rollup/rollup-freebsd-arm64": "4.62.3",
+        "@rollup/rollup-freebsd-x64": "4.62.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.3",
+        "@rollup/rollup-linux-arm64-musl": "4.62.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.3",
+        "@rollup/rollup-linux-loong64-musl": "4.62.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-gnu": "4.62.3",
+        "@rollup/rollup-linux-x64-musl": "4.62.3",
+        "@rollup/rollup-openbsd-x64": "4.62.3",
+        "@rollup/rollup-openharmony-arm64": "4.62.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.3",
+        "@rollup/rollup-win32-x64-gnu": "4.62.3",
+        "@rollup/rollup-win32-x64-msvc": "4.62.3",
         "fsevents": "~2.3.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appwrite.io/console",
-  "version": "15.7.0",
+  "version": "15.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appwrite.io/console",
-      "version": "15.7.0",
+      "version": "15.8.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appwrite.io/console",
-  "version": "15.6.0",
+  "version": "15.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@appwrite.io/console",
-      "version": "15.6.0",
+      "version": "15.7.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "json-bigint": "1.0.0"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@rollup/plugin-typescript": "12.3.0",
     "@types/json-bigint": "1.0.4",
     "playwright": "1.56.1",
-    "rollup": "4.62.2",
+    "rollup": "4.62.3",
     "serve-handler": "6.1.7",
     "tslib": "2.8.1",
     "typescript": "5.9.3"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@appwrite.io/console",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "15.7.0",
+  "version": "15.8.0",
   "license": "BSD-3-Clause",
   "main": "dist/cjs/sdk.js",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@appwrite.io/console",
   "homepage": "https://appwrite.io/support",
   "description": "Appwrite is an open-source self-hosted backend server that abstracts and simplifies complex and repetitive development tasks behind a very simple REST API",
-  "version": "15.6.0",
+  "version": "15.7.0",
   "license": "BSD-3-Clause",
   "main": "dist/cjs/sdk.js",
   "exports": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -394,7 +394,7 @@ class Client {
         'x-sdk-name': 'Console',
         'x-sdk-platform': 'console',
         'x-sdk-language': 'web',
-        'x-sdk-version': '15.7.0',
+        'x-sdk-version': '15.8.0',
         'X-Appwrite-Response-Format': '1.9.5',
     };
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -394,7 +394,7 @@ class Client {
         'x-sdk-name': 'Console',
         'x-sdk-platform': 'console',
         'x-sdk-language': 'web',
-        'x-sdk-version': '15.6.0',
+        'x-sdk-version': '15.7.0',
         'X-Appwrite-Response-Format': '1.9.5',
     };
 

--- a/src/enums/build-runtime.ts
+++ b/src/enums/build-runtime.ts
@@ -9,6 +9,7 @@ export enum BuildRuntime {
     Node23 = 'node-23',
     Node24 = 'node-24',
     Node25 = 'node-25',
+    Node26 = 'node-26',
     Php80 = 'php-8.0',
     Php81 = 'php-8.1',
     Php82 = 'php-8.2',

--- a/src/enums/runtime.ts
+++ b/src/enums/runtime.ts
@@ -9,6 +9,7 @@ export enum Runtime {
     Node23 = 'node-23',
     Node24 = 'node-24',
     Node25 = 'node-25',
+    Node26 = 'node-26',
     Php80 = 'php-8.0',
     Php81 = 'php-8.1',
     Php82 = 'php-8.2',

--- a/src/models.ts
+++ b/src/models.ts
@@ -946,7 +946,7 @@ export namespace Models {
          */
         status?: DatabaseStatus;
         /**
-         * Underlying engine of the dedicated backing: postgresql, mysql, mariadb, or mongodb. A managed product (tablesdb, documentsdb, vectorsdb) reports the engine it runs on, so its type and engine can differ. Null when the database has no dedicated backing.
+         * Underlying engine of the dedicated backing: postgresql, mysql, or mongodb. A managed product (tablesdb, documentsdb, vectorsdb) reports the engine it runs on, so its type and engine can differ. Null when the database has no dedicated backing.
          */
         engine?: string;
         /**
@@ -9019,6 +9019,14 @@ export namespace Models {
          */
         type: string;
         /**
+         * Backup type that was requested. Differs from `type` when the backend could not run the requested type and took a different one instead, in which case `fallbackReason` explains why. Empty for backups taken before the requested type was recorded.
+         */
+        requestedType: string;
+        /**
+         * Why the backend ran a different backup type than the one requested. Empty when the backup ran as requested.
+         */
+        fallbackReason: string;
+        /**
          * Backup status. Possible values: pending (queued for processing), running (currently in progress), completed (successfully finished), failed (encountered an error), verified (integrity check passed).
          */
         status: string;
@@ -9705,7 +9713,7 @@ export namespace Models {
          */
         host: string;
         /**
-         * Branch port.
+         * Branch port. Null until the backing reports one.
          */
         port: number;
         /**
@@ -9725,7 +9733,7 @@ export namespace Models {
          */
         ssl: boolean;
         /**
-         * Database engine. Possible values: postgresql, mysql, mariadb, mongodb.
+         * Database engine. Possible values: postgresql, mysql, mongodb.
          */
         engine: string;
         /**
@@ -9947,6 +9955,14 @@ export namespace Models {
          */
         phase: string;
         /**
+         * Number of times a migration step has failed and been recorded.
+         */
+        attempt: number;
+        /**
+         * Reason the most recent migration step failed, empty while none has.
+         */
+        lastError: string;
+        /**
          * Number of documents still pending replication to the target.
          */
         lagDocuments: number;
@@ -10001,7 +10017,7 @@ export namespace Models {
          */
         api: string;
         /**
-         * Database engine: postgresql, mysql, mariadb, or mongodb.
+         * Database engine: postgresql, mysql, or mongodb.
          */
         engine: string;
         /**
@@ -10021,7 +10037,7 @@ export namespace Models {
          */
         hostname: string;
         /**
-         * Database port for connections.
+         * Database port for connections. Derived from the engine when the backing has not reported one yet.
          */
         connectionPort: number;
         /**
@@ -10101,7 +10117,7 @@ export namespace Models {
          */
         crossRegionReplicas: number;
         /**
-         * Maximum concurrent connections.
+         * Maximum concurrent client connections. This is the limit a client pool may reach; the engine's own max_connections reported by the status endpoint is a smaller backend limit the pooler multiplexes onto and does not constrain a client pool.
          */
         networkMaxConnections: number;
         /**
@@ -10281,7 +10297,7 @@ export namespace Models {
          */
         ready: boolean;
         /**
-         * Database engine: postgresql, mysql, mariadb, or mongodb.
+         * Database engine: postgresql, mysql, or mongodb.
          */
         engine: string;
         /**
@@ -10297,7 +10313,31 @@ export namespace Models {
          */
         connections: DatabaseStatusConnections;
         /**
-         * List of database replicas and their status.
+         * Requested replication sync mode. Possible values: async, sync, quorum. Compare with effectiveSyncMode for what the primary is enforcing.
+         */
+        syncMode: string;
+        /**
+         * Replication sync mode the primary is actually enforcing. Null when high availability is disabled or the state could not be read.
+         */
+        effectiveSyncMode?: string;
+        /**
+         * Whether the enforced replication is weaker than the requested syncMode.
+         */
+        syncDegraded: boolean;
+        /**
+         * Number of standby acknowledgements the primary waits for before a write is committed.
+         */
+        syncAcknowledgements: number;
+        /**
+         * Number of standbys registered with the primary for synchronous replication.
+         */
+        syncStandbyCount: number;
+        /**
+         * Whether the reported sync state was read from the engine. When false the state could not be confirmed and the other sync fields carry no reading.
+         */
+        syncStateConfirmed: boolean;
+        /**
+         * List of database replicas and their status. Every configured member appears, including one the backend has not brought up, which is reported as not healthy.
          */
         replicas: DatabaseStatusReplica[];
         /**
@@ -10747,11 +10787,11 @@ export namespace Models {
          */
         $id: string;
         /**
-         * Member role. Possible values: primary (accepts reads and writes), replica (read-only follower).
+         * Member role. Possible values: primary (accepts reads and writes), replica (read-only follower), unknown (placement not established; reported while a transition is moving or restarting the topology and this member has not been probed, so no member can be named the write target).
          */
         role: string;
         /**
-         * Member pod status. Possible values: provisioning (pod missing or Pending), starting (Running but not Ready), active (Running and Ready), failed (Failed phase or CrashLoopBackOff container), or the lowercased pod phase reported by the cluster.
+         * Member pod status. Possible values: pending (configured but absent from the backend topology, so nothing is bringing it up), provisioning (pod missing or Pending), starting (Running but not Ready), active (Running and Ready), failed (Failed phase or CrashLoopBackOff container), or the lowercased pod phase reported by the cluster.
          */
         status: string;
         /**
@@ -10833,9 +10873,29 @@ export namespace Models {
          */
         replicas: number;
         /**
-         * Replication sync mode. Possible values: async (asynchronous, fastest), sync (synchronous, strong consistency), quorum (quorum-based, majority of replicas must confirm).
+         * Requested replication sync mode. Possible values: async (asynchronous, fastest), sync (synchronous, strong consistency), quorum (quorum-based, majority of replicas must confirm). This is what was asked for; compare it with effectiveSyncMode for what the primary is enforcing.
          */
         syncMode: string;
+        /**
+         * Replication sync mode the primary is actually enforcing. Null when high availability is disabled or the state could not be read. A value below the requested syncMode means writes are being acknowledged with weaker durability than configured.
+         */
+        effectiveSyncMode?: string;
+        /**
+         * Whether the enforced replication is weaker than the requested syncMode.
+         */
+        syncDegraded: boolean;
+        /**
+         * Number of standby acknowledgements the primary waits for before a write is committed. Zero means writes are acknowledged locally.
+         */
+        syncAcknowledgements: number;
+        /**
+         * Number of standbys registered with the primary for synchronous replication.
+         */
+        syncStandbyCount: number;
+        /**
+         * Whether the reported sync state was read from the engine. When false the state could not be confirmed and the other sync fields carry no reading.
+         */
+        syncStateConfirmed: boolean;
         /**
          * Per-pod statuses for the primary and every replica.
          */
@@ -11463,7 +11523,7 @@ export namespace Models {
          */
         mode: string;
         /**
-         * Maximum number of pooled connections.
+         * Client-connection ceiling the pooler accepts. Enforced on MySQL and MariaDB; on PostgreSQL the pooler has no client cap, so this reports the database's advertised networkMaxConnections and cannot be set here.
          */
         maxConnections: number;
         /**
@@ -11785,7 +11845,7 @@ export namespace Models {
          */
         current: number;
         /**
-         * Maximum allowed connections.
+         * The engine's own max_connections. On a pooled database this is the backend limit the pooler multiplexes onto, not the ceiling a client pool may reach — that is networkMaxConnections on the database resource.
          */
         max: number;
     }
@@ -11795,11 +11855,11 @@ export namespace Models {
      */
     export type DatabaseStatusReplica = {
         /**
-         * StatefulSet pod index (0 = primary, 1+ = replicas).
+         * Member index within the database. Read `role` for which member accepts writes: a failover moves the primary without renumbering the indexes.
          */
         index: number;
         /**
-         * Replica role: primary or replica.
+         * Member role. Possible values: primary (accepts reads and writes), replica (read-only follower), unknown (placement not established; reported while a transition is moving or restarting the topology, so no member can be named the write target).
          */
         role: string;
         /**
@@ -13118,6 +13178,14 @@ export namespace Models {
          * Challenge type enforced when the rule matches.
          */
         challengeType: string;
+        /**
+         * Challenge difficulty from 1 (easiest) to 5 (hardest) enforced when the rule matches.
+         */
+        difficulty: number;
+        /**
+         * Seconds a visitor stays cleared after passing the challenge before being challenged again.
+         */
+        ttl: number;
     }
 
     /**
@@ -13188,6 +13256,10 @@ export namespace Models {
          * Interval in seconds for the rate limit window.
          */
         interval: number;
+        /**
+         * Rate limit key: `ip` limits per client IP, `userId` limits per authenticated user.
+         */
+        key: string;
     }
 
     /**

--- a/src/models.ts
+++ b/src/models.ts
@@ -13055,6 +13055,72 @@ export namespace Models {
     }
 
     /**
+     * WafRuleChallenge
+     */
+    export type WafRuleChallenge = {
+        /**
+         * Rule ID.
+         */
+        $id: string;
+        /**
+         * WAF rule creation time in ISO 8601 format.
+         */
+        $createdAt: string;
+        /**
+         * WAF rule last update time in ISO 8601 format.
+         */
+        $updatedAt: string;
+        /**
+         * Human friendly rule name.
+         */
+        name: string;
+        /**
+         * Optional description for the rule.
+         */
+        description: string;
+        /**
+         * Team ID.
+         */
+        teamId: string;
+        /**
+         * Project ID.
+         */
+        projectId: string;
+        /**
+         * Resource type the rule is scoped to.
+         */
+        resourceType: string;
+        /**
+         * Resource identifier. Empty for API-wide rules.
+         */
+        resourceId: string;
+        /**
+         * Action performed when the rule matches.
+         */
+        action: WafRuleAction;
+        /**
+         * Evaluation priority. Lower values execute earlier.
+         */
+        priority: number;
+        /**
+         * Whether the rule is active.
+         */
+        enabled: boolean;
+        /**
+         * List of conditions evaluated for this rule.
+         */
+        conditions: object;
+        /**
+         * Action specific configuration.
+         */
+        config: object;
+        /**
+         * Challenge type enforced when the rule matches.
+         */
+        challengeType: string;
+    }
+
+    /**
      * WafRuleRateLimit
      */
     export type WafRuleRateLimit = {

--- a/src/services/backups.ts
+++ b/src/services/backups.ts
@@ -591,18 +591,18 @@ export class Backups {
     /**
      * Create and trigger a new restoration for a backup on a project.
      * 
-     * For a backup of one database, the restoration resolves its destination before it is queued. Pass `newResourceId` to restore into that database ID, including the archived database ID to overwrite it. When `newResourceId` is omitted, a new database ID is generated and returned in `options`.
+     * For a backup of one database, the restoration resolves its destination before it is queued. When `newResourceId` is omitted, the archived database is restored in place and its own ID is returned in `options`. Pass a different `newResourceId` to restore alongside it as a new database instead.
      * 
      * The restoration migration records the archived database in `resourceId` and `resourceType`, and the resolved database in `destinationResourceId` and `destinationResourceType`. Database types are stored canonically as `database`, `documentsdb`, or `vectorsdb`. Project-wide restorations leave these fields empty because they do not have a single source or destination database.
      * 
      * To list every migration related to one database, use its canonical type in a nested `OR(AND(...), AND(...), AND(...))` across the root, parent, and destination relation pairs: `(resourceType, resourceId)`, `(parentResourceType, parentResourceId)`, and `(destinationResourceType, destinationResourceId)`. Legacy and TablesDB databases use `database`; the operational `resourceType` of a table migration is not rewritten to `tablesdb`.
      * 
-     * When restoring a DocumentsDB or VectorsDB database to a new resource from a dedicated source, the restore provisions a fresh dedicated backing database at the source database's own specification.
+     * When restoring a DocumentsDB or VectorsDB database from a dedicated source, the restore provisions a fresh dedicated backing database at the source database's own specification and lands the data there. An in-place restore swaps the database onto that backing only once the restore has succeeded, and retires the backing it displaced only once that swap is confirmed, so the source keeps serving its own data until the restored data is in place and any failure leaves it untouched. A serverless source has no dedicated backing to clone and restores onto the archived database instead.
      * 
      *
      * @param {string} params.archiveId - Backup archive ID to restore
      * @param {BackupServices[]} params.services - Array of services to restore
-     * @param {string} params.newResourceId - Destination resource ID. Omit to generate a new ID, or pass the archived resource ID to overwrite it. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.
+     * @param {string} params.newResourceId - Destination resource ID. Omit to restore the archived resource in place, or pass a different ID to restore alongside it as a new resource. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.
      * @param {string} params.newResourceName - Database name. Max length: 128 chars.
      * @throws {AppwriteException}
      * @returns {Promise<Models.BackupRestoration>}
@@ -611,18 +611,18 @@ export class Backups {
     /**
      * Create and trigger a new restoration for a backup on a project.
      * 
-     * For a backup of one database, the restoration resolves its destination before it is queued. Pass `newResourceId` to restore into that database ID, including the archived database ID to overwrite it. When `newResourceId` is omitted, a new database ID is generated and returned in `options`.
+     * For a backup of one database, the restoration resolves its destination before it is queued. When `newResourceId` is omitted, the archived database is restored in place and its own ID is returned in `options`. Pass a different `newResourceId` to restore alongside it as a new database instead.
      * 
      * The restoration migration records the archived database in `resourceId` and `resourceType`, and the resolved database in `destinationResourceId` and `destinationResourceType`. Database types are stored canonically as `database`, `documentsdb`, or `vectorsdb`. Project-wide restorations leave these fields empty because they do not have a single source or destination database.
      * 
      * To list every migration related to one database, use its canonical type in a nested `OR(AND(...), AND(...), AND(...))` across the root, parent, and destination relation pairs: `(resourceType, resourceId)`, `(parentResourceType, parentResourceId)`, and `(destinationResourceType, destinationResourceId)`. Legacy and TablesDB databases use `database`; the operational `resourceType` of a table migration is not rewritten to `tablesdb`.
      * 
-     * When restoring a DocumentsDB or VectorsDB database to a new resource from a dedicated source, the restore provisions a fresh dedicated backing database at the source database's own specification.
+     * When restoring a DocumentsDB or VectorsDB database from a dedicated source, the restore provisions a fresh dedicated backing database at the source database's own specification and lands the data there. An in-place restore swaps the database onto that backing only once the restore has succeeded, and retires the backing it displaced only once that swap is confirmed, so the source keeps serving its own data until the restored data is in place and any failure leaves it untouched. A serverless source has no dedicated backing to clone and restores onto the archived database instead.
      * 
      *
      * @param {string} archiveId - Backup archive ID to restore
      * @param {BackupServices[]} services - Array of services to restore
-     * @param {string} newResourceId - Destination resource ID. Omit to generate a new ID, or pass the archived resource ID to overwrite it. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.
+     * @param {string} newResourceId - Destination resource ID. Omit to restore the archived resource in place, or pass a different ID to restore alongside it as a new resource. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.
      * @param {string} newResourceName - Database name. Max length: 128 chars.
      * @throws {AppwriteException}
      * @returns {Promise<Models.BackupRestoration>}

--- a/src/services/documents-db.ts
+++ b/src/services/documents-db.ts
@@ -82,10 +82,11 @@ export class DocumentsDB {
      * @param {boolean} params.enabled - Is the database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} params.specification - Database specification. Defaults to `serverless`, which creates the database on the shared pool. Any other value provisions a dedicated database on that specification.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Requires a dedicated `specification`; must be 0 for a serverless database. High availability is enabled when greater than 0.
+     * @param {string} params.syncMode - Replication sync mode for the dedicated database backing this database. Requires a dedicated `specification`; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    create(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
+    create(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string }): Promise<Models.Database>;
     /**
      * Create a new Database.
      * 
@@ -95,26 +96,28 @@ export class DocumentsDB {
      * @param {boolean} enabled - Is the database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} specification - Database specification. Defaults to `serverless`, which creates the database on the shared pool. Any other value provisions a dedicated database on that specification.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Requires a dedicated `specification`; must be 0 for a serverless database. High availability is enabled when greater than 0.
+     * @param {string} syncMode - Replication sync mode for the dedicated database backing this database. Requires a dedicated `specification`; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    create(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
+    create(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string): Promise<Models.Database>;
     create(
-        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?, (string)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
                 specification: rest[2] as string,
-                replicas: rest[3] as number            
+                replicas: rest[3] as number,
+                syncMode: rest[4] as string            
             };
         }
         
@@ -123,6 +126,7 @@ export class DocumentsDB {
         const enabled = params.enabled;
         const specification = params.specification;
         const replicas = params.replicas;
+        const syncMode = params.syncMode;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -147,6 +151,9 @@ export class DocumentsDB {
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
+        }
+        if (typeof syncMode !== 'undefined') {
+            payload['syncMode'] = syncMode;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
@@ -532,10 +539,11 @@ export class DocumentsDB {
      * @param {boolean} params.enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} params.specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
+     * @param {string} params.syncMode - Replication sync mode for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    update(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
+    update(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string }): Promise<Models.Database>;
     /**
      * Update a database by its unique ID.
      *
@@ -544,26 +552,28 @@ export class DocumentsDB {
      * @param {boolean} enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
+     * @param {string} syncMode - Replication sync mode for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    update(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
+    update(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string): Promise<Models.Database>;
     update(
-        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?, (string)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
                 specification: rest[2] as string,
-                replicas: rest[3] as number            
+                replicas: rest[3] as number,
+                syncMode: rest[4] as string            
             };
         }
         
@@ -572,6 +582,7 @@ export class DocumentsDB {
         const enabled = params.enabled;
         const specification = params.specification;
         const replicas = params.replicas;
+        const syncMode = params.syncMode;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -593,6 +604,9 @@ export class DocumentsDB {
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
+        }
+        if (typeof syncMode !== 'undefined') {
+            payload['syncMode'] = syncMode;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 

--- a/src/services/documents-db.ts
+++ b/src/services/documents-db.ts
@@ -530,43 +530,47 @@ export class DocumentsDB {
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.name - Database name. Max length: 128 chars.
      * @param {boolean} params.enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
+     * @param {string} params.specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    update(params: { databaseId: string, name: string, enabled?: boolean, replicas?: number }): Promise<Models.Database>;
+    update(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
     /**
      * Update a database by its unique ID.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} name - Database name. Max length: 128 chars.
      * @param {boolean} enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
+     * @param {string} specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    update(databaseId: string, name: string, enabled?: boolean, replicas?: number): Promise<Models.Database>;
+    update(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
     update(
-        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name: string, enabled?: boolean, replicas?: number };
+        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
-                replicas: rest[2] as number            
+                specification: rest[2] as string,
+                replicas: rest[3] as number            
             };
         }
         
         const databaseId = params.databaseId;
         const name = params.name;
         const enabled = params.enabled;
+        const specification = params.specification;
         const replicas = params.replicas;
 
         if (typeof databaseId === 'undefined') {
@@ -583,6 +587,9 @@ export class DocumentsDB {
         }
         if (typeof enabled !== 'undefined') {
             payload['enabled'] = enabled;
+        }
+        if (typeof specification !== 'undefined') {
+            payload['specification'] = specification;
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
@@ -2404,7 +2411,7 @@ export class DocumentsDB {
     }
 
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.
@@ -2413,7 +2420,7 @@ export class DocumentsDB {
      */
     createFailover(params: { databaseId: string, targetReplicaId?: string }): Promise<Models.DedicatedDatabase>;
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.

--- a/src/services/mongo.ts
+++ b/src/services/mongo.ts
@@ -1554,7 +1554,7 @@ export class Mongo {
     }
 
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.
@@ -1563,7 +1563,7 @@ export class Mongo {
      */
     createFailover(params: { databaseId: string, targetReplicaId?: string }): Promise<Models.DedicatedDatabase>;
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.

--- a/src/services/mongo.ts
+++ b/src/services/mongo.ts
@@ -81,11 +81,10 @@ export class Mongo {
      * @param {boolean} params.storageAutoscaling - Enable automatic storage expansion when usage exceeds threshold.
      * @param {number} params.storageAutoscalingThresholdPercent - Storage usage percentage (50-95) that triggers automatic expansion.
      * @param {number} params.storageAutoscalingMaxGb - Maximum storage size in GB for autoscaling. 0 means no limit.
-     * @param {string} params.api - Product API that owns this database: tablesdb, documentsdb, or vectorsdb. Omit for a raw database reached directly; its api is its engine. tablesdb/documentsdb/vectorsdb databases are reached only through their product APIs.
      * @throws {AppwriteException}
      * @returns {Promise<Models.DedicatedDatabase>}
      */
-    create(params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string }): Promise<Models.DedicatedDatabase>;
+    create(params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number }): Promise<Models.DedicatedDatabase>;
     /**
      * Create a new dedicated database with the chosen engine and configuration. Status will be 'provisioning' until the database is ready.
      *
@@ -104,20 +103,19 @@ export class Mongo {
      * @param {boolean} storageAutoscaling - Enable automatic storage expansion when usage exceeds threshold.
      * @param {number} storageAutoscalingThresholdPercent - Storage usage percentage (50-95) that triggers automatic expansion.
      * @param {number} storageAutoscalingMaxGb - Maximum storage size in GB for autoscaling. 0 means no limit.
-     * @param {string} api - Product API that owns this database: tablesdb, documentsdb, or vectorsdb. Omit for a raw database reached directly; its api is its engine. tablesdb/documentsdb/vectorsdb databases are reached only through their product APIs.
      * @throws {AppwriteException}
      * @returns {Promise<Models.DedicatedDatabase>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    create(databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string): Promise<Models.DedicatedDatabase>;
+    create(databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number): Promise<Models.DedicatedDatabase>;
     create(
-        paramsOrFirst: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string } | string,
-        ...rest: [(string)?, (string)?, (string)?, (number)?, (string)?, (string)?, (number)?, (string[])?, (number)?, (boolean)?, (number)?, (boolean)?, (number)?, (number)?, (string)?]    
+        paramsOrFirst: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number } | string,
+        ...rest: [(string)?, (string)?, (string)?, (number)?, (string)?, (string)?, (number)?, (string[])?, (number)?, (boolean)?, (number)?, (boolean)?, (number)?, (number)?]    
     ): Promise<Models.DedicatedDatabase> {
-        let params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string };
+        let params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
@@ -134,8 +132,7 @@ export class Mongo {
                 pitrRetentionDays: rest[10] as number,
                 storageAutoscaling: rest[11] as boolean,
                 storageAutoscalingThresholdPercent: rest[12] as number,
-                storageAutoscalingMaxGb: rest[13] as number,
-                api: rest[14] as string            
+                storageAutoscalingMaxGb: rest[13] as number            
             };
         }
         
@@ -154,7 +151,6 @@ export class Mongo {
         const storageAutoscaling = params.storageAutoscaling;
         const storageAutoscalingThresholdPercent = params.storageAutoscalingThresholdPercent;
         const storageAutoscalingMaxGb = params.storageAutoscalingMaxGb;
-        const api = params.api;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -209,9 +205,6 @@ export class Mongo {
         }
         if (typeof storageAutoscalingMaxGb !== 'undefined') {
             payload['storageAutoscalingMaxGb'] = storageAutoscalingMaxGb;
-        }
-        if (typeof api !== 'undefined') {
-            payload['api'] = api;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 

--- a/src/services/mysql.ts
+++ b/src/services/mysql.ts
@@ -1633,7 +1633,7 @@ export class Mysql {
     }
 
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.
@@ -1642,7 +1642,7 @@ export class Mysql {
      */
     createFailover(params: { databaseId: string, targetReplicaId?: string }): Promise<Models.DedicatedDatabase>;
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.

--- a/src/services/mysql.ts
+++ b/src/services/mysql.ts
@@ -81,11 +81,10 @@ export class Mysql {
      * @param {boolean} params.storageAutoscaling - Enable automatic storage expansion when usage exceeds threshold.
      * @param {number} params.storageAutoscalingThresholdPercent - Storage usage percentage (50-95) that triggers automatic expansion.
      * @param {number} params.storageAutoscalingMaxGb - Maximum storage size in GB for autoscaling. 0 means no limit.
-     * @param {string} params.api - Product API that owns this database: tablesdb, documentsdb, or vectorsdb. Omit for a raw database reached directly; its api is its engine. tablesdb/documentsdb/vectorsdb databases are reached only through their product APIs.
      * @throws {AppwriteException}
      * @returns {Promise<Models.DedicatedDatabase>}
      */
-    create(params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string }): Promise<Models.DedicatedDatabase>;
+    create(params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number }): Promise<Models.DedicatedDatabase>;
     /**
      * Create a new dedicated database with the chosen engine and configuration. Status will be 'provisioning' until the database is ready.
      *
@@ -104,20 +103,19 @@ export class Mysql {
      * @param {boolean} storageAutoscaling - Enable automatic storage expansion when usage exceeds threshold.
      * @param {number} storageAutoscalingThresholdPercent - Storage usage percentage (50-95) that triggers automatic expansion.
      * @param {number} storageAutoscalingMaxGb - Maximum storage size in GB for autoscaling. 0 means no limit.
-     * @param {string} api - Product API that owns this database: tablesdb, documentsdb, or vectorsdb. Omit for a raw database reached directly; its api is its engine. tablesdb/documentsdb/vectorsdb databases are reached only through their product APIs.
      * @throws {AppwriteException}
      * @returns {Promise<Models.DedicatedDatabase>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    create(databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string): Promise<Models.DedicatedDatabase>;
+    create(databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number): Promise<Models.DedicatedDatabase>;
     create(
-        paramsOrFirst: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string } | string,
-        ...rest: [(string)?, (string)?, (string)?, (number)?, (string)?, (string)?, (number)?, (string[])?, (number)?, (boolean)?, (number)?, (boolean)?, (number)?, (number)?, (string)?]    
+        paramsOrFirst: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number } | string,
+        ...rest: [(string)?, (string)?, (string)?, (number)?, (string)?, (string)?, (number)?, (string[])?, (number)?, (boolean)?, (number)?, (boolean)?, (number)?, (number)?]    
     ): Promise<Models.DedicatedDatabase> {
-        let params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string };
+        let params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
@@ -134,8 +132,7 @@ export class Mysql {
                 pitrRetentionDays: rest[10] as number,
                 storageAutoscaling: rest[11] as boolean,
                 storageAutoscalingThresholdPercent: rest[12] as number,
-                storageAutoscalingMaxGb: rest[13] as number,
-                api: rest[14] as string            
+                storageAutoscalingMaxGb: rest[13] as number            
             };
         }
         
@@ -154,7 +151,6 @@ export class Mysql {
         const storageAutoscaling = params.storageAutoscaling;
         const storageAutoscalingThresholdPercent = params.storageAutoscalingThresholdPercent;
         const storageAutoscalingMaxGb = params.storageAutoscalingMaxGb;
-        const api = params.api;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -209,9 +205,6 @@ export class Mysql {
         }
         if (typeof storageAutoscalingMaxGb !== 'undefined') {
             payload['storageAutoscalingMaxGb'] = storageAutoscalingMaxGb;
-        }
-        if (typeof api !== 'undefined') {
-            payload['api'] = api;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
@@ -2027,7 +2020,7 @@ export class Mysql {
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.mode - Connection pool mode. Allowed values: transaction, session. Transaction mode returns connections to the pool after each transaction; session mode holds connections for the entire session lifetime.
-     * @param {number} params.maxConnections - Maximum pooled connections.
+     * @param {number} params.maxConnections - Client-connection ceiling the pooler accepts. Supported on MySQL and MariaDB only; the PostgreSQL pooler has no client cap, so set networkMaxConnections on the database instead.
      * @param {number} params.defaultPoolSize - Default pool size per user.
      * @param {boolean} params.readWriteSplitting - Route SELECTs to HA replicas, writes and locked reads to the primary. Defaults to true when HA is enabled.
      * @param {string} params.poolerCpuRequest - Pooler sidecar CPU request override (Kubernetes quantity, e.g. "250m" or "1"). Leave null for the proportional default (5% of DB CPU, floor 100m).
@@ -2043,7 +2036,7 @@ export class Mysql {
      *
      * @param {string} databaseId - Database ID.
      * @param {string} mode - Connection pool mode. Allowed values: transaction, session. Transaction mode returns connections to the pool after each transaction; session mode holds connections for the entire session lifetime.
-     * @param {number} maxConnections - Maximum pooled connections.
+     * @param {number} maxConnections - Client-connection ceiling the pooler accepts. Supported on MySQL and MariaDB only; the PostgreSQL pooler has no client cap, so set networkMaxConnections on the database instead.
      * @param {number} defaultPoolSize - Default pool size per user.
      * @param {boolean} readWriteSplitting - Route SELECTs to HA replicas, writes and locked reads to the primary. Defaults to true when HA is enabled.
      * @param {string} poolerCpuRequest - Pooler sidecar CPU request override (Kubernetes quantity, e.g. "250m" or "1"). Leave null for the proportional default (5% of DB CPU, floor 100m).

--- a/src/services/postgresql.ts
+++ b/src/services/postgresql.ts
@@ -1813,7 +1813,7 @@ export class Postgresql {
     }
 
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.
@@ -1822,7 +1822,7 @@ export class Postgresql {
      */
     createFailover(params: { databaseId: string, targetReplicaId?: string }): Promise<Models.DedicatedDatabase>;
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.

--- a/src/services/postgresql.ts
+++ b/src/services/postgresql.ts
@@ -81,11 +81,10 @@ export class Postgresql {
      * @param {boolean} params.storageAutoscaling - Enable automatic storage expansion when usage exceeds threshold.
      * @param {number} params.storageAutoscalingThresholdPercent - Storage usage percentage (50-95) that triggers automatic expansion.
      * @param {number} params.storageAutoscalingMaxGb - Maximum storage size in GB for autoscaling. 0 means no limit.
-     * @param {string} params.api - Product API that owns this database: tablesdb, documentsdb, or vectorsdb. Omit for a raw database reached directly; its api is its engine. tablesdb/documentsdb/vectorsdb databases are reached only through their product APIs.
      * @throws {AppwriteException}
      * @returns {Promise<Models.DedicatedDatabase>}
      */
-    create(params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string }): Promise<Models.DedicatedDatabase>;
+    create(params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number }): Promise<Models.DedicatedDatabase>;
     /**
      * Create a new dedicated database with the chosen engine and configuration. Status will be 'provisioning' until the database is ready.
      *
@@ -104,20 +103,19 @@ export class Postgresql {
      * @param {boolean} storageAutoscaling - Enable automatic storage expansion when usage exceeds threshold.
      * @param {number} storageAutoscalingThresholdPercent - Storage usage percentage (50-95) that triggers automatic expansion.
      * @param {number} storageAutoscalingMaxGb - Maximum storage size in GB for autoscaling. 0 means no limit.
-     * @param {string} api - Product API that owns this database: tablesdb, documentsdb, or vectorsdb. Omit for a raw database reached directly; its api is its engine. tablesdb/documentsdb/vectorsdb databases are reached only through their product APIs.
      * @throws {AppwriteException}
      * @returns {Promise<Models.DedicatedDatabase>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    create(databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string): Promise<Models.DedicatedDatabase>;
+    create(databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number): Promise<Models.DedicatedDatabase>;
     create(
-        paramsOrFirst: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string } | string,
-        ...rest: [(string)?, (string)?, (string)?, (number)?, (string)?, (string)?, (number)?, (string[])?, (number)?, (boolean)?, (number)?, (boolean)?, (number)?, (number)?, (string)?]    
+        paramsOrFirst: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number } | string,
+        ...rest: [(string)?, (string)?, (string)?, (number)?, (string)?, (string)?, (number)?, (string[])?, (number)?, (boolean)?, (number)?, (boolean)?, (number)?, (number)?]    
     ): Promise<Models.DedicatedDatabase> {
-        let params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string };
+        let params: { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number, api?: string };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, version?: string, specification?: string, replicas?: number, syncMode?: string, standbyRegion?: string, networkIdleTimeoutSeconds?: number, networkIPAllowlist?: string[], idleTimeoutMinutes?: number, pitr?: boolean, pitrRetentionDays?: number, storageAutoscaling?: boolean, storageAutoscalingThresholdPercent?: number, storageAutoscalingMaxGb?: number };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
@@ -134,8 +132,7 @@ export class Postgresql {
                 pitrRetentionDays: rest[10] as number,
                 storageAutoscaling: rest[11] as boolean,
                 storageAutoscalingThresholdPercent: rest[12] as number,
-                storageAutoscalingMaxGb: rest[13] as number,
-                api: rest[14] as string            
+                storageAutoscalingMaxGb: rest[13] as number            
             };
         }
         
@@ -154,7 +151,6 @@ export class Postgresql {
         const storageAutoscaling = params.storageAutoscaling;
         const storageAutoscalingThresholdPercent = params.storageAutoscalingThresholdPercent;
         const storageAutoscalingMaxGb = params.storageAutoscalingMaxGb;
-        const api = params.api;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -209,9 +205,6 @@ export class Postgresql {
         }
         if (typeof storageAutoscalingMaxGb !== 'undefined') {
             payload['storageAutoscalingMaxGb'] = storageAutoscalingMaxGb;
-        }
-        if (typeof api !== 'undefined') {
-            payload['api'] = api;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
@@ -2207,7 +2200,7 @@ export class Postgresql {
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.mode - Connection pool mode. Allowed values: transaction, session. Transaction mode returns connections to the pool after each transaction; session mode holds connections for the entire session lifetime.
-     * @param {number} params.maxConnections - Maximum pooled connections.
+     * @param {number} params.maxConnections - Client-connection ceiling the pooler accepts. Supported on MySQL and MariaDB only; the PostgreSQL pooler has no client cap, so set networkMaxConnections on the database instead.
      * @param {number} params.defaultPoolSize - Default pool size per user.
      * @param {boolean} params.readWriteSplitting - Route SELECTs to HA replicas, writes and locked reads to the primary. Defaults to true when HA is enabled.
      * @param {string} params.poolerCpuRequest - Pooler sidecar CPU request override (Kubernetes quantity, e.g. "250m" or "1"). Leave null for the proportional default (5% of DB CPU, floor 100m).
@@ -2223,7 +2216,7 @@ export class Postgresql {
      *
      * @param {string} databaseId - Database ID.
      * @param {string} mode - Connection pool mode. Allowed values: transaction, session. Transaction mode returns connections to the pool after each transaction; session mode holds connections for the entire session lifetime.
-     * @param {number} maxConnections - Maximum pooled connections.
+     * @param {number} maxConnections - Client-connection ceiling the pooler accepts. Supported on MySQL and MariaDB only; the PostgreSQL pooler has no client cap, so set networkMaxConnections on the database instead.
      * @param {number} defaultPoolSize - Default pool size per user.
      * @param {boolean} readWriteSplitting - Route SELECTs to HA replicas, writes and locked reads to the primary. Defaults to true when HA is enabled.
      * @param {string} poolerCpuRequest - Pooler sidecar CPU request override (Kubernetes quantity, e.g. "250m" or "1"). Leave null for the proportional default (5% of DB CPU, floor 100m).

--- a/src/services/project.ts
+++ b/src/services/project.ts
@@ -5642,7 +5642,7 @@ export class Project {
      * 
      * Keep in mind, while password history policy is disabled, the history is not being stored. Enabling the policy will not have any history on existing users, and it will only start to collect and enforce the policy on password changes since the policy is enabled.
      *
-     * @param {number} params.total - Set the password history length per user. Value can be between 1 and 5000, or null to disable the limit.
+     * @param {number} params.total - Set the password history length per user. Value can be between 1 and 20, or null to disable the limit.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Project>}
      */
@@ -5652,7 +5652,7 @@ export class Project {
      * 
      * Keep in mind, while password history policy is disabled, the history is not being stored. Enabling the policy will not have any history on existing users, and it will only start to collect and enforce the policy on password changes since the policy is enabled.
      *
-     * @param {number} total - Set the password history length per user. Value can be between 1 and 5000, or null to disable the limit.
+     * @param {number} total - Set the password history length per user. Value can be between 1 and 20, or null to disable the limit.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Project>}
      * @deprecated Use the object parameter style method for a better developer experience.
@@ -5898,7 +5898,7 @@ export class Project {
     /**
      * Update maximum duration how long sessions created within a project should stay active for.
      *
-     * @param {number} params.duration - Maximum session length in seconds. Minium allowed value is 5 second, and maximum is 1 year, which is 31536000 seconds.
+     * @param {number} params.duration - Maximum session length in seconds. Minium allowed value is 60 seconds, and maximum is 1 year, which is 31536000 seconds.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Project>}
      */
@@ -5906,7 +5906,7 @@ export class Project {
     /**
      * Update maximum duration how long sessions created within a project should stay active for.
      *
-     * @param {number} duration - Maximum session length in seconds. Minium allowed value is 5 second, and maximum is 1 year, which is 31536000 seconds.
+     * @param {number} duration - Maximum session length in seconds. Minium allowed value is 60 seconds, and maximum is 1 year, which is 31536000 seconds.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Project>}
      * @deprecated Use the object parameter style method for a better developer experience.
@@ -6012,27 +6012,27 @@ export class Project {
     /**
      * Update the maximum number of sessions allowed per user. When the limit is hit, the oldest session will be deleted to make room for new one.
      *
-     * @param {number} params.total - Set the maximum number of sessions allowed per user. Value can be between 1 and 5000, or null to disable the limit.
+     * @param {number} params.total - Set the maximum number of sessions allowed per user. Value can be between 1 and 100.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Project>}
      */
-    updateSessionLimitPolicy(params: { total?: number }): Promise<Models.Project>;
+    updateSessionLimitPolicy(params: { total: number }): Promise<Models.Project>;
     /**
      * Update the maximum number of sessions allowed per user. When the limit is hit, the oldest session will be deleted to make room for new one.
      *
-     * @param {number} total - Set the maximum number of sessions allowed per user. Value can be between 1 and 5000, or null to disable the limit.
+     * @param {number} total - Set the maximum number of sessions allowed per user. Value can be between 1 and 100.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Project>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    updateSessionLimitPolicy(total?: number): Promise<Models.Project>;
+    updateSessionLimitPolicy(total: number): Promise<Models.Project>;
     updateSessionLimitPolicy(
-        paramsOrFirst?: { total?: number } | number    
+        paramsOrFirst: { total: number } | number    
     ): Promise<Models.Project> {
-        let params: { total?: number };
+        let params: { total: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { total?: number };
+            params = (paramsOrFirst || {}) as { total: number };
         } else {
             params = {
                 total: paramsOrFirst as number            
@@ -6069,7 +6069,7 @@ export class Project {
     /**
      * Update the maximum number of users in the project. When the limit is hit or amount of existing users already exceeded the limit, all users remain active, but new user sign up will be prohibited.
      *
-     * @param {number} params.total - Set the maximum number of users allowed in the project. Value can be between 1 and 5000, or null to disable the limit.
+     * @param {number} params.total - Set the maximum number of users allowed in the project. Value can be between 0 and 10000. Use 0 or null to disable the limit.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Project>}
      */
@@ -6077,7 +6077,7 @@ export class Project {
     /**
      * Update the maximum number of users in the project. When the limit is hit or amount of existing users already exceeded the limit, all users remain active, but new user sign up will be prohibited.
      *
-     * @param {number} total - Set the maximum number of users allowed in the project. Value can be between 1 and 5000, or null to disable the limit.
+     * @param {number} total - Set the maximum number of users allowed in the project. Value can be between 0 and 10000. Use 0 or null to disable the limit.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Project>}
      * @deprecated Use the object parameter style method for a better developer experience.

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -535,10 +535,11 @@ export class Storage {
      * @param {string} params.fileId - File ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.
      * @param {File} params.file - Binary file. Appwrite SDKs provide helpers to handle file input. [Learn about file input](https://appwrite.io/docs/products/storage/upload-download#input-file).
      * @param {string[]} params.permissions - An array of permission strings. By default, only the current user is granted all permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).
+     * @param {string} params.folder - Virtual folder to place the file in, for example "photos/2026". Nest folders with `/`. Defaults to the bucket root.
      * @throws {AppwriteException}
      * @returns {Promise<Models.File>}
      */
-    createFile(params: { bucketId: string, fileId: string, file: File, permissions?: string[], onProgress?: (progress: UploadProgress) => void }): Promise<Models.File>;
+    createFile(params: { bucketId: string, fileId: string, file: File, permissions?: string[], folder?: string, onProgress?: (progress: UploadProgress) => void }): Promise<Models.File>;
     /**
      * Create a new file. Before using this route, you should create a new bucket resource using either a [server integration](https://appwrite.io/docs/server/storage#storageCreateBucket) API or directly from your Appwrite console.
      * 
@@ -553,35 +554,38 @@ export class Storage {
      * @param {string} fileId - File ID. Choose a custom ID or generate a random ID with `ID.unique()`. Valid chars are a-z, A-Z, 0-9, period, hyphen, and underscore. Can't start with a special char. Max length is 36 chars.
      * @param {File} file - Binary file. Appwrite SDKs provide helpers to handle file input. [Learn about file input](https://appwrite.io/docs/products/storage/upload-download#input-file).
      * @param {string[]} permissions - An array of permission strings. By default, only the current user is granted all permissions. [Learn more about permissions](https://appwrite.io/docs/permissions).
+     * @param {string} folder - Virtual folder to place the file in, for example "photos/2026". Nest folders with `/`. Defaults to the bucket root.
      * @throws {AppwriteException}
      * @returns {Promise<Models.File>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    createFile(bucketId: string, fileId: string, file: File, permissions?: string[], onProgress?: (progress: UploadProgress) => void): Promise<Models.File>;
+    createFile(bucketId: string, fileId: string, file: File, permissions?: string[], folder?: string, onProgress?: (progress: UploadProgress) => void): Promise<Models.File>;
     createFile(
-        paramsOrFirst: { bucketId: string, fileId: string, file: File, permissions?: string[], onProgress?: (progress: UploadProgress) => void } | string,
-        ...rest: [(string)?, (File)?, (string[])?,((progress: UploadProgress) => void)?]    
+        paramsOrFirst: { bucketId: string, fileId: string, file: File, permissions?: string[], folder?: string, onProgress?: (progress: UploadProgress) => void } | string,
+        ...rest: [(string)?, (File)?, (string[])?, (string)?,((progress: UploadProgress) => void)?]    
     ): Promise<Models.File> {
-        let params: { bucketId: string, fileId: string, file: File, permissions?: string[] };
+        let params: { bucketId: string, fileId: string, file: File, permissions?: string[], folder?: string };
         let onProgress: ((progress: UploadProgress) => void);
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { bucketId: string, fileId: string, file: File, permissions?: string[] };
+            params = (paramsOrFirst || {}) as { bucketId: string, fileId: string, file: File, permissions?: string[], folder?: string };
             onProgress = paramsOrFirst?.onProgress as ((progress: UploadProgress) => void);
         } else {
             params = {
                 bucketId: paramsOrFirst as string,
                 fileId: rest[0] as string,
                 file: rest[1] as File,
-                permissions: rest[2] as string[]            
+                permissions: rest[2] as string[],
+                folder: rest[3] as string            
             };
-            onProgress = rest[3] as ((progress: UploadProgress) => void);
+            onProgress = rest[4] as ((progress: UploadProgress) => void);
         }
         
         const bucketId = params.bucketId;
         const fileId = params.fileId;
         const file = params.file;
         const permissions = params.permissions;
+        const folder = params.folder;
 
         if (typeof bucketId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "bucketId"');
@@ -603,6 +607,9 @@ export class Storage {
         }
         if (typeof permissions !== 'undefined') {
             payload['permissions'] = permissions;
+        }
+        if (typeof folder !== 'undefined') {
+            payload['folder'] = folder;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 

--- a/src/services/tables-db.ts
+++ b/src/services/tables-db.ts
@@ -91,10 +91,11 @@ export class TablesDB {
      * @param {boolean} params.enabled - Is the database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} params.specification - Database specification. Defaults to `serverless`, which creates the database on the shared pool. Any other value provisions a dedicated database on that specification.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Requires a dedicated `specification`; must be 0 for a serverless database. High availability is enabled when greater than 0.
+     * @param {string} params.syncMode - Replication sync mode for the dedicated database backing this database. Requires a dedicated `specification`; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    create(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
+    create(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string }): Promise<Models.Database>;
     /**
      * Create a new Database.
      * 
@@ -104,26 +105,28 @@ export class TablesDB {
      * @param {boolean} enabled - Is the database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} specification - Database specification. Defaults to `serverless`, which creates the database on the shared pool. Any other value provisions a dedicated database on that specification.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Requires a dedicated `specification`; must be 0 for a serverless database. High availability is enabled when greater than 0.
+     * @param {string} syncMode - Replication sync mode for the dedicated database backing this database. Requires a dedicated `specification`; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    create(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
+    create(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string): Promise<Models.Database>;
     create(
-        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?, (string)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
                 specification: rest[2] as string,
-                replicas: rest[3] as number            
+                replicas: rest[3] as number,
+                syncMode: rest[4] as string            
             };
         }
         
@@ -132,6 +135,7 @@ export class TablesDB {
         const enabled = params.enabled;
         const specification = params.specification;
         const replicas = params.replicas;
+        const syncMode = params.syncMode;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -156,6 +160,9 @@ export class TablesDB {
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
+        }
+        if (typeof syncMode !== 'undefined') {
+            payload['syncMode'] = syncMode;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
@@ -603,10 +610,11 @@ export class TablesDB {
      * @param {boolean} params.enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} params.specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
+     * @param {string} params.syncMode - Replication sync mode for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    update(params: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
+    update(params: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string }): Promise<Models.Database>;
     /**
      * Update a database by its unique ID.
      *
@@ -615,26 +623,28 @@ export class TablesDB {
      * @param {boolean} enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
+     * @param {string} syncMode - Replication sync mode for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    update(databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
+    update(databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string): Promise<Models.Database>;
     update(
-        paramsOrFirst: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?, (string)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number };
+        let params: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
                 specification: rest[2] as string,
-                replicas: rest[3] as number            
+                replicas: rest[3] as number,
+                syncMode: rest[4] as string            
             };
         }
         
@@ -643,6 +653,7 @@ export class TablesDB {
         const enabled = params.enabled;
         const specification = params.specification;
         const replicas = params.replicas;
+        const syncMode = params.syncMode;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -661,6 +672,9 @@ export class TablesDB {
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
+        }
+        if (typeof syncMode !== 'undefined') {
+            payload['syncMode'] = syncMode;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 

--- a/src/services/tables-db.ts
+++ b/src/services/tables-db.ts
@@ -601,43 +601,47 @@ export class TablesDB {
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.name - Database name. Max length: 128 chars.
      * @param {boolean} params.enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
+     * @param {string} params.specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    update(params: { databaseId: string, name?: string, enabled?: boolean, replicas?: number }): Promise<Models.Database>;
+    update(params: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
     /**
      * Update a database by its unique ID.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} name - Database name. Max length: 128 chars.
      * @param {boolean} enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
+     * @param {string} specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    update(databaseId: string, name?: string, enabled?: boolean, replicas?: number): Promise<Models.Database>;
+    update(databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
     update(
-        paramsOrFirst: { databaseId: string, name?: string, enabled?: boolean, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name?: string, enabled?: boolean, replicas?: number };
+        let params: { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name?: string, enabled?: boolean, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name?: string, enabled?: boolean, specification?: string, replicas?: number };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
-                replicas: rest[2] as number            
+                specification: rest[2] as string,
+                replicas: rest[3] as number            
             };
         }
         
         const databaseId = params.databaseId;
         const name = params.name;
         const enabled = params.enabled;
+        const specification = params.specification;
         const replicas = params.replicas;
 
         if (typeof databaseId === 'undefined') {
@@ -651,6 +655,9 @@ export class TablesDB {
         }
         if (typeof enabled !== 'undefined') {
             payload['enabled'] = enabled;
+        }
+        if (typeof specification !== 'undefined') {
+            payload['specification'] = specification;
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
@@ -725,7 +732,7 @@ export class TablesDB {
     }
 
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.
@@ -734,7 +741,7 @@ export class TablesDB {
      */
     createFailover(params: { databaseId: string, targetReplicaId?: string }): Promise<Models.DedicatedDatabase>;
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.

--- a/src/services/vectors-db.ts
+++ b/src/services/vectors-db.ts
@@ -660,43 +660,47 @@ export class VectorsDB {
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.name - Database name. Max length: 128 chars.
      * @param {boolean} params.enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
+     * @param {string} params.specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    update(params: { databaseId: string, name: string, enabled?: boolean, replicas?: number }): Promise<Models.Database>;
+    update(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
     /**
      * Update a database by its unique ID.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} name - Database name. Max length: 128 chars.
      * @param {boolean} enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
+     * @param {string} specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    update(databaseId: string, name: string, enabled?: boolean, replicas?: number): Promise<Models.Database>;
+    update(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
     update(
-        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name: string, enabled?: boolean, replicas?: number };
+        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
-                replicas: rest[2] as number            
+                specification: rest[2] as string,
+                replicas: rest[3] as number            
             };
         }
         
         const databaseId = params.databaseId;
         const name = params.name;
         const enabled = params.enabled;
+        const specification = params.specification;
         const replicas = params.replicas;
 
         if (typeof databaseId === 'undefined') {
@@ -713,6 +717,9 @@ export class VectorsDB {
         }
         if (typeof enabled !== 'undefined') {
             payload['enabled'] = enabled;
+        }
+        if (typeof specification !== 'undefined') {
+            payload['specification'] = specification;
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
@@ -2428,7 +2435,7 @@ export class VectorsDB {
     }
 
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} params.databaseId - Database ID.
      * @param {string} params.targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.
@@ -2437,7 +2444,7 @@ export class VectorsDB {
      */
     createFailover(params: { databaseId: string, targetReplicaId?: string }): Promise<Models.DedicatedDatabase>;
     /**
-     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates.
+     * Trigger a manual failover for a dedicated database with high availability enabled. Promotes a replica to primary. The failover runs asynchronously; poll the database document for status updates. A database left mid-operation by a failover that did not finish also accepts this call as a repair, provided `targetReplicaId` names the member to promote.
      *
      * @param {string} databaseId - Database ID.
      * @param {string} targetReplicaId - Target replica ID to promote. If not specified, the healthiest replica is selected.

--- a/src/services/vectors-db.ts
+++ b/src/services/vectors-db.ts
@@ -83,10 +83,11 @@ export class VectorsDB {
      * @param {boolean} params.enabled - Is the database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} params.specification - Database specification. Defaults to `serverless`, which creates the database on the shared pool. Any other value provisions a dedicated database on that specification.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Requires a dedicated `specification`; must be 0 for a serverless database. High availability is enabled when greater than 0.
+     * @param {string} params.syncMode - Replication sync mode for the dedicated database backing this database. Requires a dedicated `specification`; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    create(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
+    create(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string }): Promise<Models.Database>;
     /**
      * Create a new Database.
      * 
@@ -96,26 +97,28 @@ export class VectorsDB {
      * @param {boolean} enabled - Is the database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} specification - Database specification. Defaults to `serverless`, which creates the database on the shared pool. Any other value provisions a dedicated database on that specification.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Requires a dedicated `specification`; must be 0 for a serverless database. High availability is enabled when greater than 0.
+     * @param {string} syncMode - Replication sync mode for the dedicated database backing this database. Requires a dedicated `specification`; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    create(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
+    create(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string): Promise<Models.Database>;
     create(
-        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?, (string)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
                 specification: rest[2] as string,
-                replicas: rest[3] as number            
+                replicas: rest[3] as number,
+                syncMode: rest[4] as string            
             };
         }
         
@@ -124,6 +127,7 @@ export class VectorsDB {
         const enabled = params.enabled;
         const specification = params.specification;
         const replicas = params.replicas;
+        const syncMode = params.syncMode;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -148,6 +152,9 @@ export class VectorsDB {
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
+        }
+        if (typeof syncMode !== 'undefined') {
+            payload['syncMode'] = syncMode;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
@@ -662,10 +669,11 @@ export class VectorsDB {
      * @param {boolean} params.enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} params.specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} params.replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
+     * @param {string} params.syncMode - Replication sync mode for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      */
-    update(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number }): Promise<Models.Database>;
+    update(params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string }): Promise<Models.Database>;
     /**
      * Update a database by its unique ID.
      *
@@ -674,26 +682,28 @@ export class VectorsDB {
      * @param {boolean} enabled - Is database enabled? When set to 'disabled', users cannot access the database but Server SDKs with an API key can still read and write to the database. No data is lost when this is toggled.
      * @param {string} specification - Database specification. Resizing between dedicated specifications changes cpu, memory, storage and the connection ceiling via a rolling cutover with zero downtime. Moving a `serverless` database onto a dedicated specification is a data migration, not a resize.
      * @param {number} replicas - Number of high availability replicas (0-5) for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification. High availability is enabled when greater than 0.
+     * @param {string} syncMode - Replication sync mode for the dedicated database backing this database. Only valid when the database is backed by a dedicated specification; the mode is only in force once there is at least one replica. Allowed values: async, sync, quorum.
      * @throws {AppwriteException}
      * @returns {Promise<Models.Database>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    update(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number): Promise<Models.Database>;
+    update(databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string): Promise<Models.Database>;
     update(
-        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number } | string,
-        ...rest: [(string)?, (boolean)?, (string)?, (number)?]    
+        paramsOrFirst: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string } | string,
+        ...rest: [(string)?, (boolean)?, (string)?, (number)?, (string)?]    
     ): Promise<Models.Database> {
-        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+        let params: { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number };
+            params = (paramsOrFirst || {}) as { databaseId: string, name: string, enabled?: boolean, specification?: string, replicas?: number, syncMode?: string };
         } else {
             params = {
                 databaseId: paramsOrFirst as string,
                 name: rest[0] as string,
                 enabled: rest[1] as boolean,
                 specification: rest[2] as string,
-                replicas: rest[3] as number            
+                replicas: rest[3] as number,
+                syncMode: rest[4] as string            
             };
         }
         
@@ -702,6 +712,7 @@ export class VectorsDB {
         const enabled = params.enabled;
         const specification = params.specification;
         const replicas = params.replicas;
+        const syncMode = params.syncMode;
 
         if (typeof databaseId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "databaseId"');
@@ -723,6 +734,9 @@ export class VectorsDB {
         }
         if (typeof replicas !== 'undefined') {
             payload['replicas'] = replicas;
+        }
+        if (typeof syncMode !== 'undefined') {
+            payload['syncMode'] = syncMode;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 

--- a/src/services/waf.ts
+++ b/src/services/waf.ts
@@ -81,7 +81,7 @@ export class Waf {
     }
 
     /**
-     * Create a bypass WAF rule.
+     * Create a bypass WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -97,7 +97,7 @@ export class Waf {
      */
     createBypassRule(params: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleBypass>;
     /**
-     * Create a bypass WAF rule.
+     * Create a bypass WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -196,7 +196,7 @@ export class Waf {
     }
 
     /**
-     * Update a bypass WAF rule.
+     * Update a bypass WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID.
@@ -212,7 +212,7 @@ export class Waf {
      */
     updateBypassRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleBypass>;
     /**
-     * Update a bypass WAF rule.
+     * Update a bypass WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID.
@@ -302,7 +302,242 @@ export class Waf {
     }
 
     /**
-     * Create a deny WAF rule.
+     * Create a challenge WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * 
+     *
+     * @param {string} params.ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
+     * @param {string} params.resourceType - Resource type the rule applies to.
+     * @param {string} params.name - Rule name.
+     * @param {string} params.resourceId - Resource identifier. Required for functions and sites.
+     * @param {string} params.description - Optional description for the rule.
+     * @param {string} params.challengeType - Challenge type enforced by the rule.
+     * @param {number} params.priority - Evaluation priority. Lower numbers run earlier.
+     * @param {boolean} params.enabled - Set to false to create the rule in a disabled state.
+     * @param {string} params.conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.WafRuleChallenge>}
+     */
+    createChallengeRule(params: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleChallenge>;
+    /**
+     * Create a challenge WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * 
+     *
+     * @param {string} ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
+     * @param {string} resourceType - Resource type the rule applies to.
+     * @param {string} name - Rule name.
+     * @param {string} resourceId - Resource identifier. Required for functions and sites.
+     * @param {string} description - Optional description for the rule.
+     * @param {string} challengeType - Challenge type enforced by the rule.
+     * @param {number} priority - Evaluation priority. Lower numbers run earlier.
+     * @param {boolean} enabled - Set to false to create the rule in a disabled state.
+     * @param {string} conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.WafRuleChallenge>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    createChallengeRule(ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string): Promise<Models.WafRuleChallenge>;
+    createChallengeRule(
+        paramsOrFirst: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string } | string,
+        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (number)?, (boolean)?, (string)?]    
+    ): Promise<Models.WafRuleChallenge> {
+        let params: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string };
+        } else {
+            params = {
+                ruleId: paramsOrFirst as string,
+                resourceType: rest[0] as string,
+                name: rest[1] as string,
+                resourceId: rest[2] as string,
+                description: rest[3] as string,
+                challengeType: rest[4] as string,
+                priority: rest[5] as number,
+                enabled: rest[6] as boolean,
+                conditions: rest[7] as string            
+            };
+        }
+        
+        const ruleId = params.ruleId;
+        const resourceType = params.resourceType;
+        const name = params.name;
+        const resourceId = params.resourceId;
+        const description = params.description;
+        const challengeType = params.challengeType;
+        const priority = params.priority;
+        const enabled = params.enabled;
+        const conditions = params.conditions;
+
+        if (typeof ruleId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "ruleId"');
+        }
+        if (typeof resourceType === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "resourceType"');
+        }
+        if (typeof name === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "name"');
+        }
+
+        const apiPath = '/waf/rules/challenge';
+        const payload: Payload = {};
+        if (typeof ruleId !== 'undefined') {
+            payload['ruleId'] = ruleId;
+        }
+        if (typeof resourceType !== 'undefined') {
+            payload['resourceType'] = resourceType;
+        }
+        if (typeof resourceId !== 'undefined') {
+            payload['resourceId'] = resourceId;
+        }
+        if (typeof name !== 'undefined') {
+            payload['name'] = name;
+        }
+        if (typeof description !== 'undefined') {
+            payload['description'] = description;
+        }
+        if (typeof challengeType !== 'undefined') {
+            payload['challengeType'] = challengeType;
+        }
+        if (typeof priority !== 'undefined') {
+            payload['priority'] = priority;
+        }
+        if (typeof enabled !== 'undefined') {
+            payload['enabled'] = enabled;
+        }
+        if (typeof conditions !== 'undefined') {
+            payload['conditions'] = conditions;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'content-type': 'application/json',
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'post',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
+     * Update a challenge WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * 
+     *
+     * @param {string} params.ruleId - Rule ID.
+     * @param {string} params.resourceType - Resource type the rule applies to.
+     * @param {string} params.resourceId - Resource identifier. Required for functions and sites.
+     * @param {string} params.name - Rule name.
+     * @param {string} params.description - Optional description for the rule.
+     * @param {string} params.challengeType - Challenge type enforced by the rule.
+     * @param {number} params.priority - Evaluation priority. Lower numbers run earlier.
+     * @param {boolean} params.enabled - Set to false to disable the rule.
+     * @param {string} params.conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.WafRuleChallenge>}
+     */
+    updateChallengeRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleChallenge>;
+    /**
+     * Update a challenge WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * 
+     *
+     * @param {string} ruleId - Rule ID.
+     * @param {string} resourceType - Resource type the rule applies to.
+     * @param {string} resourceId - Resource identifier. Required for functions and sites.
+     * @param {string} name - Rule name.
+     * @param {string} description - Optional description for the rule.
+     * @param {string} challengeType - Challenge type enforced by the rule.
+     * @param {number} priority - Evaluation priority. Lower numbers run earlier.
+     * @param {boolean} enabled - Set to false to disable the rule.
+     * @param {string} conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
+     * @throws {AppwriteException}
+     * @returns {Promise<Models.WafRuleChallenge>}
+     * @deprecated Use the object parameter style method for a better developer experience.
+     */
+    updateChallengeRule(ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string): Promise<Models.WafRuleChallenge>;
+    updateChallengeRule(
+        paramsOrFirst: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string } | string,
+        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (number)?, (boolean)?, (string)?]    
+    ): Promise<Models.WafRuleChallenge> {
+        let params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string };
+        
+        if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
+            params = (paramsOrFirst || {}) as { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string };
+        } else {
+            params = {
+                ruleId: paramsOrFirst as string,
+                resourceType: rest[0] as string,
+                resourceId: rest[1] as string,
+                name: rest[2] as string,
+                description: rest[3] as string,
+                challengeType: rest[4] as string,
+                priority: rest[5] as number,
+                enabled: rest[6] as boolean,
+                conditions: rest[7] as string            
+            };
+        }
+        
+        const ruleId = params.ruleId;
+        const resourceType = params.resourceType;
+        const resourceId = params.resourceId;
+        const name = params.name;
+        const description = params.description;
+        const challengeType = params.challengeType;
+        const priority = params.priority;
+        const enabled = params.enabled;
+        const conditions = params.conditions;
+
+        if (typeof ruleId === 'undefined') {
+            throw new AppwriteException('Missing required parameter: "ruleId"');
+        }
+
+        const apiPath = '/waf/rules/challenge/{ruleId}'.replace('{ruleId}', encodeURIComponent(String(ruleId)));
+        const payload: Payload = {};
+        if (typeof resourceType !== 'undefined') {
+            payload['resourceType'] = resourceType;
+        }
+        if (typeof resourceId !== 'undefined') {
+            payload['resourceId'] = resourceId;
+        }
+        if (typeof name !== 'undefined') {
+            payload['name'] = name;
+        }
+        if (typeof description !== 'undefined') {
+            payload['description'] = description;
+        }
+        if (typeof challengeType !== 'undefined') {
+            payload['challengeType'] = challengeType;
+        }
+        if (typeof priority !== 'undefined') {
+            payload['priority'] = priority;
+        }
+        if (typeof enabled !== 'undefined') {
+            payload['enabled'] = enabled;
+        }
+        if (typeof conditions !== 'undefined') {
+            payload['conditions'] = conditions;
+        }
+        const uri = new URL(this.client.config.endpoint + apiPath);
+
+        const apiHeaders: { [header: string]: string } = {
+            'X-Appwrite-Project': this.client.config.project,
+            'content-type': 'application/json',
+            'accept': 'application/json',
+        }
+
+        return this.client.call(
+            'patch',
+            uri,
+            apiHeaders,
+            payload
+        );
+    }
+
+    /**
+     * Create a deny WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -318,7 +553,7 @@ export class Waf {
      */
     createDenyRule(params: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleDeny>;
     /**
-     * Create a deny WAF rule.
+     * Create a deny WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -417,7 +652,7 @@ export class Waf {
     }
 
     /**
-     * Update a deny WAF rule.
+     * Update a deny WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID.
@@ -433,7 +668,7 @@ export class Waf {
      */
     updateDenyRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleDeny>;
     /**
-     * Update a deny WAF rule.
+     * Update a deny WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID.
@@ -523,7 +758,7 @@ export class Waf {
     }
 
     /**
-     * Create a rate limit WAF rule.
+     * Create a rate limit WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -541,7 +776,7 @@ export class Waf {
      */
     createRateLimitRule(params: { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleRateLimit>;
     /**
-     * Create a rate limit WAF rule.
+     * Create a rate limit WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -658,7 +893,7 @@ export class Waf {
     }
 
     /**
-     * Update a rate limit WAF rule.
+     * Update a rate limit WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID.
@@ -676,7 +911,7 @@ export class Waf {
      */
     updateRateLimitRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleRateLimit>;
     /**
-     * Update a rate limit WAF rule.
+     * Update a rate limit WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID.
@@ -778,7 +1013,7 @@ export class Waf {
     }
 
     /**
-     * Create a redirect WAF rule.
+     * Create a redirect WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -796,7 +1031,7 @@ export class Waf {
      */
     createRedirectRule(params: { ruleId: string, resourceType: string, name: string, location: string, statusCode: number, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleRedirect>;
     /**
-     * Create a redirect WAF rule.
+     * Create a redirect WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -913,7 +1148,7 @@ export class Waf {
     }
 
     /**
-     * Update a redirect WAF rule.
+     * Update a redirect WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID.
@@ -931,7 +1166,7 @@ export class Waf {
      */
     updateRedirectRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, location?: string, statusCode?: number, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleRedirect>;
     /**
-     * Update a redirect WAF rule.
+     * Update a redirect WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID.

--- a/src/services/waf.ts
+++ b/src/services/waf.ts
@@ -302,7 +302,7 @@ export class Waf {
     }
 
     /**
-     * Create a challenge WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * Create a challenge WAF rule. Use `difficulty` (1 easiest to 5 hardest) to tune the client-side proof-of-work cost, and `ttl` to control how long, in seconds, a visitor stays cleared after passing the challenge before being challenged again. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -314,12 +314,14 @@ export class Waf {
      * @param {number} params.priority - Evaluation priority. Lower numbers run earlier.
      * @param {boolean} params.enabled - Set to false to create the rule in a disabled state.
      * @param {string} params.conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
+     * @param {number} params.difficulty - Challenge difficulty from 1 (easiest) to 5 (hardest). Higher values demand more client-side proof-of-work.
+     * @param {number} params.ttl - How long, in seconds, a visitor stays cleared after passing the challenge before being challenged again.
      * @throws {AppwriteException}
      * @returns {Promise<Models.WafRuleChallenge>}
      */
-    createChallengeRule(params: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleChallenge>;
+    createChallengeRule(params: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number }): Promise<Models.WafRuleChallenge>;
     /**
-     * Create a challenge WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * Create a challenge WAF rule. Use `difficulty` (1 easiest to 5 hardest) to tune the client-side proof-of-work cost, and `ttl` to control how long, in seconds, a visitor stays cleared after passing the challenge before being challenged again. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -331,19 +333,21 @@ export class Waf {
      * @param {number} priority - Evaluation priority. Lower numbers run earlier.
      * @param {boolean} enabled - Set to false to create the rule in a disabled state.
      * @param {string} conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
+     * @param {number} difficulty - Challenge difficulty from 1 (easiest) to 5 (hardest). Higher values demand more client-side proof-of-work.
+     * @param {number} ttl - How long, in seconds, a visitor stays cleared after passing the challenge before being challenged again.
      * @throws {AppwriteException}
      * @returns {Promise<Models.WafRuleChallenge>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    createChallengeRule(ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string): Promise<Models.WafRuleChallenge>;
+    createChallengeRule(ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number): Promise<Models.WafRuleChallenge>;
     createChallengeRule(
-        paramsOrFirst: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string } | string,
-        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (number)?, (boolean)?, (string)?]    
+        paramsOrFirst: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number } | string,
+        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (number)?, (boolean)?, (string)?, (number)?, (number)?]    
     ): Promise<Models.WafRuleChallenge> {
-        let params: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string };
+        let params: { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string };
+            params = (paramsOrFirst || {}) as { ruleId: string, resourceType: string, name: string, resourceId?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number };
         } else {
             params = {
                 ruleId: paramsOrFirst as string,
@@ -354,7 +358,9 @@ export class Waf {
                 challengeType: rest[4] as string,
                 priority: rest[5] as number,
                 enabled: rest[6] as boolean,
-                conditions: rest[7] as string            
+                conditions: rest[7] as string,
+                difficulty: rest[8] as number,
+                ttl: rest[9] as number            
             };
         }
         
@@ -367,6 +373,8 @@ export class Waf {
         const priority = params.priority;
         const enabled = params.enabled;
         const conditions = params.conditions;
+        const difficulty = params.difficulty;
+        const ttl = params.ttl;
 
         if (typeof ruleId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "ruleId"');
@@ -407,6 +415,12 @@ export class Waf {
         if (typeof conditions !== 'undefined') {
             payload['conditions'] = conditions;
         }
+        if (typeof difficulty !== 'undefined') {
+            payload['difficulty'] = difficulty;
+        }
+        if (typeof ttl !== 'undefined') {
+            payload['ttl'] = ttl;
+        }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
         const apiHeaders: { [header: string]: string } = {
@@ -424,7 +438,7 @@ export class Waf {
     }
 
     /**
-     * Update a challenge WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * Update a challenge WAF rule. Use `difficulty` (1 easiest to 5 hardest) to tune the client-side proof-of-work cost, and `ttl` to control how long, in seconds, a visitor stays cleared after passing the challenge before being challenged again. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID.
@@ -436,12 +450,14 @@ export class Waf {
      * @param {number} params.priority - Evaluation priority. Lower numbers run earlier.
      * @param {boolean} params.enabled - Set to false to disable the rule.
      * @param {string} params.conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
+     * @param {number} params.difficulty - Challenge difficulty from 1 (easiest) to 5 (hardest). Higher values demand more client-side proof-of-work.
+     * @param {number} params.ttl - How long, in seconds, a visitor stays cleared after passing the challenge before being challenged again.
      * @throws {AppwriteException}
      * @returns {Promise<Models.WafRuleChallenge>}
      */
-    updateChallengeRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleChallenge>;
+    updateChallengeRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number }): Promise<Models.WafRuleChallenge>;
     /**
-     * Update a challenge WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * Update a challenge WAF rule. Use `difficulty` (1 easiest to 5 hardest) to tune the client-side proof-of-work cost, and `ttl` to control how long, in seconds, a visitor stays cleared after passing the challenge before being challenged again. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID.
@@ -453,19 +469,21 @@ export class Waf {
      * @param {number} priority - Evaluation priority. Lower numbers run earlier.
      * @param {boolean} enabled - Set to false to disable the rule.
      * @param {string} conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
+     * @param {number} difficulty - Challenge difficulty from 1 (easiest) to 5 (hardest). Higher values demand more client-side proof-of-work.
+     * @param {number} ttl - How long, in seconds, a visitor stays cleared after passing the challenge before being challenged again.
      * @throws {AppwriteException}
      * @returns {Promise<Models.WafRuleChallenge>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    updateChallengeRule(ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string): Promise<Models.WafRuleChallenge>;
+    updateChallengeRule(ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number): Promise<Models.WafRuleChallenge>;
     updateChallengeRule(
-        paramsOrFirst: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string } | string,
-        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (number)?, (boolean)?, (string)?]    
+        paramsOrFirst: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number } | string,
+        ...rest: [(string)?, (string)?, (string)?, (string)?, (string)?, (number)?, (boolean)?, (string)?, (number)?, (number)?]    
     ): Promise<Models.WafRuleChallenge> {
-        let params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string };
+        let params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string };
+            params = (paramsOrFirst || {}) as { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, challengeType?: string, priority?: number, enabled?: boolean, conditions?: string, difficulty?: number, ttl?: number };
         } else {
             params = {
                 ruleId: paramsOrFirst as string,
@@ -476,7 +494,9 @@ export class Waf {
                 challengeType: rest[4] as string,
                 priority: rest[5] as number,
                 enabled: rest[6] as boolean,
-                conditions: rest[7] as string            
+                conditions: rest[7] as string,
+                difficulty: rest[8] as number,
+                ttl: rest[9] as number            
             };
         }
         
@@ -489,6 +509,8 @@ export class Waf {
         const priority = params.priority;
         const enabled = params.enabled;
         const conditions = params.conditions;
+        const difficulty = params.difficulty;
+        const ttl = params.ttl;
 
         if (typeof ruleId === 'undefined') {
             throw new AppwriteException('Missing required parameter: "ruleId"');
@@ -519,6 +541,12 @@ export class Waf {
         }
         if (typeof conditions !== 'undefined') {
             payload['conditions'] = conditions;
+        }
+        if (typeof difficulty !== 'undefined') {
+            payload['difficulty'] = difficulty;
+        }
+        if (typeof ttl !== 'undefined') {
+            payload['ttl'] = ttl;
         }
         const uri = new URL(this.client.config.endpoint + apiPath);
 
@@ -758,7 +786,7 @@ export class Waf {
     }
 
     /**
-     * Create a rate limit WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * Create a rate limit WAF rule. Use `key` to choose the counter: `ip` limits per client IP, while `userId` limits per authenticated user (requests without an authenticated user skip `userId` rules). Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -768,15 +796,16 @@ export class Waf {
      * @param {number} params.interval - Interval in seconds used for rate limiting.
      * @param {string} params.resourceId - Resource identifier. Required for functions and sites.
      * @param {string} params.description - Optional description for the rule.
+     * @param {string} params.key - Rate limit key. Use `ip` to limit per client IP or `userId` to limit per authenticated user. Requests without an authenticated user skip `userId` rules.
      * @param {number} params.priority - Evaluation priority. Lower numbers run earlier.
      * @param {boolean} params.enabled - Set to false to create the rule in a disabled state.
      * @param {string} params.conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
      * @throws {AppwriteException}
      * @returns {Promise<Models.WafRuleRateLimit>}
      */
-    createRateLimitRule(params: { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleRateLimit>;
+    createRateLimitRule(params: { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, key?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleRateLimit>;
     /**
-     * Create a rate limit WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * Create a rate limit WAF rule. Use `key` to choose the counter: `ip` limits per client IP, while `userId` limits per authenticated user (requests without an authenticated user skip `userId` rules). Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID. Choose a custom ID or pass `ID.unique()` to generate a unique one.
@@ -786,6 +815,7 @@ export class Waf {
      * @param {number} interval - Interval in seconds used for rate limiting.
      * @param {string} resourceId - Resource identifier. Required for functions and sites.
      * @param {string} description - Optional description for the rule.
+     * @param {string} key - Rate limit key. Use `ip` to limit per client IP or `userId` to limit per authenticated user. Requests without an authenticated user skip `userId` rules.
      * @param {number} priority - Evaluation priority. Lower numbers run earlier.
      * @param {boolean} enabled - Set to false to create the rule in a disabled state.
      * @param {string} conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
@@ -793,15 +823,15 @@ export class Waf {
      * @returns {Promise<Models.WafRuleRateLimit>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    createRateLimitRule(ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string): Promise<Models.WafRuleRateLimit>;
+    createRateLimitRule(ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, key?: string, priority?: number, enabled?: boolean, conditions?: string): Promise<Models.WafRuleRateLimit>;
     createRateLimitRule(
-        paramsOrFirst: { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string } | string,
-        ...rest: [(string)?, (string)?, (number)?, (number)?, (string)?, (string)?, (number)?, (boolean)?, (string)?]    
+        paramsOrFirst: { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, key?: string, priority?: number, enabled?: boolean, conditions?: string } | string,
+        ...rest: [(string)?, (string)?, (number)?, (number)?, (string)?, (string)?, (string)?, (number)?, (boolean)?, (string)?]    
     ): Promise<Models.WafRuleRateLimit> {
-        let params: { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string };
+        let params: { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, key?: string, priority?: number, enabled?: boolean, conditions?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, priority?: number, enabled?: boolean, conditions?: string };
+            params = (paramsOrFirst || {}) as { ruleId: string, resourceType: string, name: string, limit: number, interval: number, resourceId?: string, description?: string, key?: string, priority?: number, enabled?: boolean, conditions?: string };
         } else {
             params = {
                 ruleId: paramsOrFirst as string,
@@ -811,9 +841,10 @@ export class Waf {
                 interval: rest[3] as number,
                 resourceId: rest[4] as string,
                 description: rest[5] as string,
-                priority: rest[6] as number,
-                enabled: rest[7] as boolean,
-                conditions: rest[8] as string            
+                key: rest[6] as string,
+                priority: rest[7] as number,
+                enabled: rest[8] as boolean,
+                conditions: rest[9] as string            
             };
         }
         
@@ -824,6 +855,7 @@ export class Waf {
         const interval = params.interval;
         const resourceId = params.resourceId;
         const description = params.description;
+        const key = params.key;
         const priority = params.priority;
         const enabled = params.enabled;
         const conditions = params.conditions;
@@ -867,6 +899,9 @@ export class Waf {
         if (typeof interval !== 'undefined') {
             payload['interval'] = interval;
         }
+        if (typeof key !== 'undefined') {
+            payload['key'] = key;
+        }
         if (typeof priority !== 'undefined') {
             payload['priority'] = priority;
         }
@@ -893,7 +928,7 @@ export class Waf {
     }
 
     /**
-     * Update a rate limit WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * Update a rate limit WAF rule. Use `key` to choose the counter: `ip` limits per client IP, while `userId` limits per authenticated user (requests without an authenticated user skip `userId` rules). Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} params.ruleId - Rule ID.
@@ -903,15 +938,16 @@ export class Waf {
      * @param {string} params.description - Optional description for the rule.
      * @param {number} params.limit - Maximum number of matching requests allowed in the configured interval.
      * @param {number} params.interval - Interval in seconds used for rate limiting.
+     * @param {string} params.key - Rate limit key. Use `ip` to limit per client IP or `userId` to limit per authenticated user. Requests without an authenticated user skip `userId` rules.
      * @param {number} params.priority - Evaluation priority. Lower numbers run earlier.
      * @param {boolean} params.enabled - Set to false to disable the rule.
      * @param {string} params.conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
      * @throws {AppwriteException}
      * @returns {Promise<Models.WafRuleRateLimit>}
      */
-    updateRateLimitRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleRateLimit>;
+    updateRateLimitRule(params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, key?: string, priority?: number, enabled?: boolean, conditions?: string }): Promise<Models.WafRuleRateLimit>;
     /**
-     * Update a rate limit WAF rule. Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
+     * Update a rate limit WAF rule. Use `key` to choose the counter: `ip` limits per client IP, while `userId` limits per authenticated user (requests without an authenticated user skip `userId` rules). Conditions can match request attributes including `ip` (plain IPs or CIDR blocks like `10.0.0.0/8`), `method`, `path`, `host`, `country`, `continent`, `headers.<name>`, `query.<key>`, `queryKeys`, `userAgent`, `os`, `osVersion`, `browser`, and `browserVersion`. Conditions on `city` and `state` require the premium Geo DB addon.
      * 
      *
      * @param {string} ruleId - Rule ID.
@@ -921,6 +957,7 @@ export class Waf {
      * @param {string} description - Optional description for the rule.
      * @param {number} limit - Maximum number of matching requests allowed in the configured interval.
      * @param {number} interval - Interval in seconds used for rate limiting.
+     * @param {string} key - Rate limit key. Use `ip` to limit per client IP or `userId` to limit per authenticated user. Requests without an authenticated user skip `userId` rules.
      * @param {number} priority - Evaluation priority. Lower numbers run earlier.
      * @param {boolean} enabled - Set to false to disable the rule.
      * @param {string} conditions - Array of condition strings generated using the WAF Condition builder. Maximum of 100 conditions are allowed, each 4096 characters long.
@@ -928,15 +965,15 @@ export class Waf {
      * @returns {Promise<Models.WafRuleRateLimit>}
      * @deprecated Use the object parameter style method for a better developer experience.
      */
-    updateRateLimitRule(ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, priority?: number, enabled?: boolean, conditions?: string): Promise<Models.WafRuleRateLimit>;
+    updateRateLimitRule(ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, key?: string, priority?: number, enabled?: boolean, conditions?: string): Promise<Models.WafRuleRateLimit>;
     updateRateLimitRule(
-        paramsOrFirst: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, priority?: number, enabled?: boolean, conditions?: string } | string,
-        ...rest: [(string)?, (string)?, (string)?, (string)?, (number)?, (number)?, (number)?, (boolean)?, (string)?]    
+        paramsOrFirst: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, key?: string, priority?: number, enabled?: boolean, conditions?: string } | string,
+        ...rest: [(string)?, (string)?, (string)?, (string)?, (number)?, (number)?, (string)?, (number)?, (boolean)?, (string)?]    
     ): Promise<Models.WafRuleRateLimit> {
-        let params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, priority?: number, enabled?: boolean, conditions?: string };
+        let params: { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, key?: string, priority?: number, enabled?: boolean, conditions?: string };
         
         if ((paramsOrFirst && typeof paramsOrFirst === 'object' && !Array.isArray(paramsOrFirst))) {
-            params = (paramsOrFirst || {}) as { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, priority?: number, enabled?: boolean, conditions?: string };
+            params = (paramsOrFirst || {}) as { ruleId: string, resourceType?: string, resourceId?: string, name?: string, description?: string, limit?: number, interval?: number, key?: string, priority?: number, enabled?: boolean, conditions?: string };
         } else {
             params = {
                 ruleId: paramsOrFirst as string,
@@ -946,9 +983,10 @@ export class Waf {
                 description: rest[3] as string,
                 limit: rest[4] as number,
                 interval: rest[5] as number,
-                priority: rest[6] as number,
-                enabled: rest[7] as boolean,
-                conditions: rest[8] as string            
+                key: rest[6] as string,
+                priority: rest[7] as number,
+                enabled: rest[8] as boolean,
+                conditions: rest[9] as string            
             };
         }
         
@@ -959,6 +997,7 @@ export class Waf {
         const description = params.description;
         const limit = params.limit;
         const interval = params.interval;
+        const key = params.key;
         const priority = params.priority;
         const enabled = params.enabled;
         const conditions = params.conditions;
@@ -986,6 +1025,9 @@ export class Waf {
         }
         if (typeof interval !== 'undefined') {
             payload['interval'] = interval;
+        }
+        if (typeof key !== 'undefined') {
+            payload['key'] = key;
         }
         if (typeof priority !== 'undefined') {
             payload['priority'] = priority;


### PR DESCRIPTION
This PR contains updates to the Console SDK for version 15.8.0.

## What's Changed

* Breaking: `create()` on `mysql`, `postgresql`, and `mongo` no longer accepts `api`
* Breaking: `project.updateSessionLimitPolicy()` now requires `total`
* Added: `syncMode` parameter to `create()` and `update()` on `tablesDB`, `documentsDB`, and `vectorsDB`
* Added: `difficulty` and `ttl` parameters to `waf.createChallengeRule()` and `waf.updateChallengeRule()`
* Added: `key` parameter to `waf.createRateLimitRule()` and `waf.updateRateLimitRule()`
* Added: replication sync state fields to `DatabaseStatus` and `DedicatedDatabaseReplicas`
* Added: `syncMode` to the `DedicatedDatabase` model
* Added: `difficulty` and `ttl` to `WafRuleChallenge`, and `key` to `WafRuleRateLimit`
* Added: `requestedType` and `fallbackReason` to `DedicatedDatabaseBackup`
* Added: `attempt` and `lastError` to `DatabaseMigration`
* Added: `node-26` to the `Runtime` and `BuildRuntime` enums
* Updated: `DatabaseStatusReplica.role` documents the `unknown` role during topology transitions
* Updated: Project policy limits for password history, session duration, session count, and users